### PR TITLE
🏗 Support BuildRequests

### DIFF
--- a/plugins/module_utils/raw.py
+++ b/plugins/module_utils/raw.py
@@ -178,6 +178,9 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             if kind.endswith('List'):
                 resource = self.find_resource(kind, api_version, fail=False)
                 flattened_definitions.extend(self.flatten_list_kind(resource, definition))
+            elif kind == 'BuildRequest':
+                resource = self.find_resource('BuildConfig', api_version, fail=True).subresources['instantiate']
+                flattened_definitions.append((resource, definition))
             else:
                 resource = self.find_resource(kind, api_version, fail=True)
                 flattened_definitions.append((resource, definition))
@@ -219,7 +222,6 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             return [_prepend_resource_info(resource, msg) for msg in warnings + errors]
 
     def set_defaults(self, resource, definition):
-        definition['kind'] = resource.kind
         definition['apiVersion'] = resource.group_version
         metadata = definition.get('metadata', {})
         if self.name and not metadata.get('name'):
@@ -263,7 +265,9 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                 pass
         except ForbiddenError as exc:
             if definition['kind'] in ['Project', 'ProjectRequest'] and state != 'absent':
-                return self.create_project_request(definition)
+                return self.create_request('ProjectRequest', definition)
+            if definition['kind'] == 'BuildRequest' and state != 'absent':
+                return self.create_request('BuildRequest', definition, resource)
             self.fail_json(msg='Failed to retrieve requested object: {0}'.format(exc.body),
                            error=exc.status, status=exc.status, reason=exc.reason)
         except DynamicApiError as exc:
@@ -419,10 +423,11 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             error = dict(msg=msg, error=exc.status, status=exc.status, reason=exc.reason, warnings=self.warnings)
             return None, error
 
-    def create_project_request(self, definition):
-        definition['kind'] = 'ProjectRequest'
+    def create_request(self, kind, definition, resource=None):
+        definition['kind'] = kind
         result = {'changed': False, 'result': {}}
-        resource = self.find_resource('ProjectRequest', definition['apiVersion'], fail=True)
+        if not resource:
+            resource = self.find_resource(kind, definition['apiVersion'], fail=True)
         if not self.check_mode:
             try:
                 k8s_obj = resource.create(definition)


### PR DESCRIPTION
##### SUMMARY
Add support for `BuildRequest` in `k8s`. 
Fixes: https://github.com/ansible/ansible/issues/52887
Replaces: https://github.com/ansible/ansible/pull/67697

##### ISSUE TYPE
- Bugfix/Feature Pull Request

##### COMPONENT NAME
Module: `k8s`

##### ADDITIONAL INFORMATION
Slight modification in `create_project_request` allows for creating any type of request if the subresource mapping is specified in `execute_module` when looking up the resource (this may be simplified if support for other subresources is needed).

Tasks like the one bellow are now supported:
```
- name: Test play
  hosts: localhost
  connection: local
  tasks:
  - name: Trigger a build
    k8s:
      namespace: <NAMESPACE>
      state: present
      definition:
        kind: BuildRequest
        apiVersion: build.openshift.io/v1
        metadata:
          name: <BUILD_CONFIG_NAME>
```