### PR TITLE
Remove ANSIBLE_METADATA

### DIFF
--- a/plugins/filter/k8s.py
+++ b/plugins/filter/k8s.py
@@ -6,13 +6,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {
-    'metadata_version': '1.1',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
-
-
 try:
     from openshift.helper.hashes import generate_hash
     HAS_GENERATE_HASH = True

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -6,9 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---

--- a/plugins/modules/helm_info.py
+++ b/plugins/modules/helm_info.py
@@ -6,9 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---

--- a/plugins/modules/helm_repository.py
+++ b/plugins/modules/helm_repository.py
@@ -6,9 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -9,10 +9,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 DOCUMENTATION = '''
 
 module: k8s

--- a/plugins/modules/k8s_auth.py
+++ b/plugins/modules/k8s_auth.py
@@ -9,10 +9,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 DOCUMENTATION = '''
 
 module: k8s_auth

--- a/plugins/modules/k8s_exec.py
+++ b/plugins/modules/k8s_exec.py
@@ -9,10 +9,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 DOCUMENTATION = '''
 
 module: k8s_exec

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -9,10 +9,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 DOCUMENTATION = '''
 module: k8s_info
 

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -9,10 +9,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 DOCUMENTATION = '''
 module: k8s_log
 

--- a/plugins/modules/k8s_scale.py
+++ b/plugins/modules/k8s_scale.py
@@ -9,9 +9,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 

--- a/plugins/modules/k8s_service.py
+++ b/plugins/modules/k8s_service.py
@@ -9,10 +9,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 DOCUMENTATION = '''
 
 module: k8s_service

--- a/tests/integration/targets/kubernetes/library/test_tempfile.py
+++ b/tests/integration/targets/kubernetes/library/test_tempfile.py
@@ -8,9 +8,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---


### PR DESCRIPTION
##### SUMMARY
The meta data field is deprecated and is not used anymore.
See ansible-collections/overview#57 for more details.

Fixes #91 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
all