### PR TITLE
Fixes #96: Sanity test finds incorrect deprecated usage.

### DIFF
--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -143,8 +143,6 @@ class KubernetesInfoModule(KubernetesAnsibleModule):
         KubernetesAnsibleModule.__init__(self, *args,
                                          supports_check_mode=True,
                                          **kwargs)
-        if self._name == 'k8s_facts':
-            self.deprecate("The 'k8s_facts' module has been renamed to 'k8s_info'", version='2.13')
 
     def execute_module(self):
         self.client = self.get_api_client()


### PR DESCRIPTION
Closes #96.﻿

Since we don't ship a `k8s_facts` module in this collection at all, we don't need to account for it being aliased to `k8s_info`.
