### PR TITLE
Fix the docs for the inventory plugins.

### DIFF
--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -28,60 +28,61 @@ DOCUMENTATION = '''
           - Optional list of cluster connection settings. If no connections are provided, the default
             I(~/.kube/config) and active context will be used, and objects will be returned for all namespaces
             the active user is authorized to access.
-          name:
-              description:
-              - Optional name to assign to the cluster. If not provided, a name is constructed from the server
-                and port.
-          kubeconfig:
-              description:
-              - Path to an existing Kubernetes config file. If not provided, and no other connection
-                options are provided, the OpenShift client will attempt to load the default
-                configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG
-                environment variable.
-          context:
-              description:
-              - The name of a context found in the config file. Can also be specified via K8S_AUTH_CONTEXT environment
-                variable.
-          host:
-              description:
-              - Provide a URL for accessing the API. Can also be specified via K8S_AUTH_HOST environment variable.
-          api_key:
-              description:
-              - Token used to authenticate with the API. Can also be specified via K8S_AUTH_API_KEY environment
-                variable.
-          username:
-              description:
-              - Provide a username for authenticating with the API. Can also be specified via K8S_AUTH_USERNAME
-                environment variable.
-          password:
-              description:
-              - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD
-                environment variable.
-          client_cert:
-              description:
-              - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE
-                environment variable.
-              aliases: [ cert_file ]
-          client_key:
-              description:
-              - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE
-                environment variable.
-              aliases: [ key_file ]
-          ca_cert:
-              description:
-              - Path to a CA certificate used to authenticate with the API. Can also be specified via
-                K8S_AUTH_SSL_CA_CERT environment variable.
-              aliases: [ ssl_ca_cert ]
-          validate_certs:
-              description:
-              - "Whether or not to verify the API server's SSL certificates. Can also be specified via
-                K8S_AUTH_VERIFY_SSL environment variable."
-              type: bool
-              aliases: [ verify_ssl ]
-          namespaces:
-              description:
-              - List of namespaces. If not specified, will fetch all containers for all namespaces user is authorized
-                to access.
+          suboptions:
+              name:
+                  description:
+                  - Optional name to assign to the cluster. If not provided, a name is constructed from the server
+                    and port.
+              kubeconfig:
+                  description:
+                  - Path to an existing Kubernetes config file. If not provided, and no other connection
+                    options are provided, the OpenShift client will attempt to load the default
+                    configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG
+                    environment variable.
+              context:
+                  description:
+                  - The name of a context found in the config file. Can also be specified via K8S_AUTH_CONTEXT environment
+                    variable.
+              host:
+                  description:
+                  - Provide a URL for accessing the API. Can also be specified via K8S_AUTH_HOST environment variable.
+              api_key:
+                  description:
+                  - Token used to authenticate with the API. Can also be specified via K8S_AUTH_API_KEY environment
+                    variable.
+              username:
+                  description:
+                  - Provide a username for authenticating with the API. Can also be specified via K8S_AUTH_USERNAME
+                    environment variable.
+              password:
+                  description:
+                  - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD
+                    environment variable.
+              client_cert:
+                  description:
+                  - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE
+                    environment variable.
+                  aliases: [ cert_file ]
+              client_key:
+                  description:
+                  - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE
+                    environment variable.
+                  aliases: [ key_file ]
+              ca_cert:
+                  description:
+                  - Path to a CA certificate used to authenticate with the API. Can also be specified via
+                    K8S_AUTH_SSL_CA_CERT environment variable.
+                  aliases: [ ssl_ca_cert ]
+              validate_certs:
+                  description:
+                  - "Whether or not to verify the API server's SSL certificates. Can also be specified via
+                    K8S_AUTH_VERIFY_SSL environment variable."
+                  type: bool
+                  aliases: [ verify_ssl ]
+              namespaces:
+                  description:
+                  - List of namespaces. If not specified, will fetch all containers for all namespaces user is authorized
+                    to access.
 
     requirements:
     - "python >= 2.7"

--- a/plugins/inventory/openshift.py
+++ b/plugins/inventory/openshift.py
@@ -28,60 +28,61 @@ DOCUMENTATION = '''
           - Optional list of cluster connection settings. If no connections are provided, the default
             I(~/.kube/config) and active context will be used, and objects will be returned for all namespaces
             the active user is authorized to access.
-          name:
-              description:
-              - Optional name to assign to the cluster. If not provided, a name is constructed from the server
-                and port.
-          kubeconfig:
-              description:
-              - Path to an existing Kubernetes config file. If not provided, and no other connection
-                options are provided, the OpenShift client will attempt to load the default
-                configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG
-                environment variable.
-          context:
-              description:
-              - The name of a context found in the config file. Can also be specified via K8S_AUTH_CONTEXT environment
-                variable.
-          host:
-              description:
-              - Provide a URL for accessing the API. Can also be specified via K8S_AUTH_HOST environment variable.
-          api_key:
-              description:
-              - Token used to authenticate with the API. Can also be specified via K8S_AUTH_API_KEY environment
-                variable.
-          username:
-              description:
-              - Provide a username for authenticating with the API. Can also be specified via K8S_AUTH_USERNAME
-                environment variable.
-          password:
-              description:
-              - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD
-                environment variable.
-          client_cert:
-              description:
-              - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE
-                environment variable.
-              aliases: [ cert_file ]
-          client_key:
-              description:
-              - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE
-                environment variable.
-              aliases: [ key_file ]
-          ca_cert:
-              description:
-              - Path to a CA certificate used to authenticate with the API. Can also be specified via
-                K8S_AUTH_SSL_CA_CERT environment variable.
-              aliases: [ ssl_ca_cert ]
-          validate_certs:
-              description:
-              - "Whether or not to verify the API server's SSL certificates. Can also be specified via
-                K8S_AUTH_VERIFY_SSL environment variable."
-              type: bool
-              aliases: [ verify_ssl ]
-          namespaces:
-              description:
-              - List of namespaces. If not specified, will fetch all containers for all namespaces user is authorized
-                to access.
+          suboptions:
+              name:
+                  description:
+                  - Optional name to assign to the cluster. If not provided, a name is constructed from the server
+                    and port.
+              kubeconfig:
+                  description:
+                  - Path to an existing Kubernetes config file. If not provided, and no other connection
+                    options are provided, the OpenShift client will attempt to load the default
+                    configuration file from I(~/.kube/config.json). Can also be specified via K8S_AUTH_KUBECONFIG
+                    environment variable.
+              context:
+                  description:
+                  - The name of a context found in the config file. Can also be specified via K8S_AUTH_CONTEXT environment
+                    variable.
+              host:
+                  description:
+                  - Provide a URL for accessing the API. Can also be specified via K8S_AUTH_HOST environment variable.
+              api_key:
+                  description:
+                  - Token used to authenticate with the API. Can also be specified via K8S_AUTH_API_KEY environment
+                    variable.
+              username:
+                  description:
+                  - Provide a username for authenticating with the API. Can also be specified via K8S_AUTH_USERNAME
+                    environment variable.
+              password:
+                  description:
+                  - Provide a password for authenticating with the API. Can also be specified via K8S_AUTH_PASSWORD
+                    environment variable.
+              client_cert:
+                  description:
+                  - Path to a certificate used to authenticate with the API. Can also be specified via K8S_AUTH_CERT_FILE
+                    environment variable.
+                  aliases: [ cert_file ]
+              client_key:
+                  description:
+                  - Path to a key file used to authenticate with the API. Can also be specified via K8S_AUTH_KEY_FILE
+                    environment variable.
+                  aliases: [ key_file ]
+              ca_cert:
+                  description:
+                  - Path to a CA certificate used to authenticate with the API. Can also be specified via
+                    K8S_AUTH_SSL_CA_CERT environment variable.
+                  aliases: [ ssl_ca_cert ]
+              validate_certs:
+                  description:
+                  - "Whether or not to verify the API server's SSL certificates. Can also be specified via
+                    K8S_AUTH_VERIFY_SSL environment variable."
+                  type: bool
+                  aliases: [ verify_ssl ]
+              namespaces:
+                  description:
+                  - List of namespaces. If not specified, will fetch all containers for all namespaces user is authorized
+                    to access.
 
     requirements:
     - "python >= 2.7"


### PR DESCRIPTION
Documenting the structure of the dictionary to pass in needs to be done
via suboptions rather than putting the structure directoly inside of the
toplevel option.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
inventory plugins

##### ADDITIONAL INFORMATION

@geerlingguy Hey, I'm working on a schema for docs.  These inventory plugins are doing things in a non-standard way and I'd like to get this fix applied so that I don't have to specialcase the code to get the documentation to show up on pages like this: https://docs.ansible.com/ansible/latest/plugins/inventory/k8s.html