### PR TITLE
Add action groups for playbooks with module_defaults

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,12 @@
+action_groups:
+  k8s:
+  - k8s
+  - k8s_auth
+  - k8s_facts
+  - k8s_info
+  - k8s_scale
+  - k8s_service
+
+action_groups_redirection:
+  k8s:
+    redirect: k8s

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,11 +1,12 @@
+---
 action_groups:
   k8s:
-  - k8s
-  - k8s_auth
-  - k8s_facts
-  - k8s_info
-  - k8s_scale
-  - k8s_service
+    - k8s
+    - k8s_auth
+    - k8s_facts
+    - k8s_info
+    - k8s_scale
+    - k8s_service
 
 action_groups_redirection:
   k8s:


### PR DESCRIPTION
##### SUMMARY
Keep backwards compatibility with playbooks using community.kubernetes content with module_defaults groups - for example

```
module_defaults:
  group/k8s:
    # set common options with default values
    option: value
tasks:
  # uses the module_default group value for the option
  - k8s_info:

  # should use the module_default group value for the option
  - community.kubernetes.k8s_info:
```

ansible/ansible#67291 adds support so the collection is no longer reliant on routing and the entries in core to keep things from breaking and now can define their own. This will also fix using `group/k8s:` with fully qualified module names.

##### ISSUE TYPE
- Bugfix Pull Request
