### PR TITLE
Minor documentation fix

### DIFF
--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -97,7 +97,7 @@ EXAMPLES = '''
 plugin: k8s
 connections:
   - host: https://192.168.64.4:8443
-    token: xxxxxxxxxxxxxxxx
+    api_key: xxxxxxxxxxxxxxxx
     validate_certs: false
 
 # Use default config (~/.kube/config) file and active context, and return objects for a specific namespace


### PR DESCRIPTION
##### SUMMARY

Inventory plugin example should read 'api_key' instead of 'token'

Fixes: #101

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/k8s.py
