### PR TITLE
Handle set object retrieved from lookup plugin

### DIFF
--- a/molecule/default/tasks/full.yml
+++ b/molecule/default/tasks/full.yml
@@ -185,6 +185,13 @@
           metadata:
             name: testing1
 
+    ### https://github.com/ansible-collections/community.kubernetes/issues/111
+    - set_fact:
+        api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+
+    - debug:
+        var: api_groups
+
     - name: Namespace should exist
       k8s_info:
         kind: Namespace

--- a/plugins/lookup/k8s.py
+++ b/plugins/lookup/k8s.py
@@ -194,11 +194,11 @@ RETURN = """
         type: complex
 """
 
+from ansible.errors import AnsibleError
+from ansible.module_utils.common._collections_compat import KeysView
 from ansible.plugins.lookup import LookupBase
 
 from ansible_collections.community.kubernetes.plugins.module_utils.common import K8sAnsibleMixin
-
-from ansible.errors import AnsibleError
 
 
 try:
@@ -253,6 +253,8 @@ class KubernetesLookup(K8sAnsibleMixin):
         if cluster_info == 'version':
             return [self.client.version]
         if cluster_info == 'api_groups':
+            if isinstance(self.client.resources.api_groups, KeysView):
+                return [list(self.client.resources.api_groups)]
             return [self.client.resources.api_groups]
 
         self.kind = kwargs.get('kind')


### PR DESCRIPTION
##### SUMMARY

self.client.resources.api_groups is a dict_keys and is not
handled correctly by default callback plugin while JSON serialization.

This fix will typecast it to list so that it can be JSON serialized for
further processing.

Fixes: #111

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
molecule/default/tasks/full.yml
plugins/lookup/k8s.py
