### PR TITLE
Issue #125: Add requires_ansible version constraints to runtime.yml.

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,6 @@
 ---
+requires_ansible: '>=2.9,<2.11'
+
 action_groups:
   k8s:
     - k8s


### PR DESCRIPTION
Closes #125.﻿

Leaving in draft state until we can choose whether to set the minimum requirement to `2.9.10` vs `2.9` (see related issue).