### PR TITLE
Remove action_groups_redirection entry from meta/runtime.yml

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -13,7 +13,3 @@ action_groups:
     - k8s_log
     - k8s_scale
     - k8s_service
-
-action_groups_redirection:
-  k8s:
-    redirect: k8s


### PR DESCRIPTION
##### SUMMARY
The `action_groups_redirection` field which was originally intended to be included in 2.10 but is going to be reconsidered for the following release instead.

@geerlingguy I noticed you added a new 'helm' group to this collection. New group names are not being supported in 2.10 after all - only the whitelisted group names in 2.9 will work to keep backwards compatibility for the time being. Do you want me to remove the helm group and the modules listed under it since it's unusued?

##### ISSUE TYPE
- Bugfix Pull Request
