### PR TITLE
helm:  Support for single or multiple values files

### DIFF
--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -81,6 +81,9 @@ options:
   values_files:
     description:
         - Value files to pass to chart.
+        - Paths will be read from the target host's filesystem, not the host running ansible.
+        - values_files option is evaluated before values option if both are used.
+        - Paths are evaluated in the order the paths are specified.
     required: false
     default: []
     type: list

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -75,13 +75,14 @@ options:
     description:
         - Value to pass to chart.
     required: false
+    default: {}
     aliases: [ values ]
     type: dict
   values_files:
     description:
         - Value files to pass to chart.
     required: false
-    default: {}
+    default: []
     type: list
     elements: str
   update_repo_cache:
@@ -357,7 +358,7 @@ def deploy(command, release_name, release_values, chart_name, wait, wait_timeout
 
     if values_files:
         for value_file in values_files:
-            deploy_command += " -f=" + value_file
+            deploy_command += " --values=" + value_file
 
     if release_values != {}:
         fd, path = tempfile.mkstemp(suffix='.yml')
@@ -400,7 +401,7 @@ def main():
             release_namespace=dict(type='str', required=True, aliases=['namespace']),
             release_state=dict(default='present', choices=['present', 'absent'], aliases=['state']),
             release_values=dict(type='dict', default={}, aliases=['values']),
-            values_files=dict(type='list'),
+            values_files=dict(type='list', default=[], elements='str'),
             update_repo_cache=dict(type='bool', default=False),
 
             # Helm options

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -75,7 +75,6 @@ options:
     description:
         - Value to pass to chart.
     required: false
-    default: {}
     aliases: [ values ]
     type: dict
   values_files:
@@ -84,7 +83,7 @@ options:
     required: false
     default: {}
     type: list
-    elemants: str
+    elements: str
   update_repo_cache:
     description:
       - Run C(helm repo update) before the operation. Can be run as part of the package installation or as a separate step.
@@ -358,7 +357,7 @@ def deploy(command, release_name, release_values, chart_name, wait, wait_timeout
 
     if values_files:
         for value_file in values_files:
-          deploy_command += " -f=" + value_file
+            deploy_command += " -f=" + value_file
 
     if release_values != {}:
         fd, path = tempfile.mkstemp(suffix='.yml')

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -333,7 +333,7 @@ def fetch_chart_info(command, chart_ref):
     return yaml.safe_load(out)
 
 
-def deploy(command, release_name, release_values, chart_name, wait, wait_timeout, disable_hook, force, atomic=False, values_files):
+def deploy(command, release_name, release_values, chart_name, wait, wait_timeout, disable_hook, force, values_files, atomic=False):
     """
     Install/upgrade/rollback release chart
     """
@@ -357,8 +357,8 @@ def deploy(command, release_name, release_values, chart_name, wait, wait_timeout
         deploy_command += " --no-hooks"
 
     if values_files:
-      for value_file in values_files:
-        deploy_command += " -f=" + value_file
+        for value_file in values_files:
+          deploy_command += " -f=" + value_file
 
     if release_values != {}:
         fd, path = tempfile.mkstemp(suffix='.yml')
@@ -484,13 +484,13 @@ def main():
 
         if release_status is None:  # Not installed
             helm_cmd = deploy(helm_cmd, release_name, release_values, chart_ref, wait, wait_timeout,
-                              disable_hook, False, atomic=atomic, values_files=values_files)
+                              disable_hook, False, values_files, atomic=atomic)
             changed = True
 
         elif force or release_values != release_status['values'] \
                 or (chart_info['name'] + '-' + chart_info['version']) != release_status["chart"]:
             helm_cmd = deploy(helm_cmd, release_name, release_values, chart_ref, wait, wait_timeout,
-                              disable_hook, force, atomic=atomic, values_files=values_files)
+                              disable_hook, force, values_files, atomic=atomic)
             changed = True
 
     if module.check_mode:


### PR DESCRIPTION
##### SUMMARY

Helm provides an option to give a list of yaml files that will be used to supply values in the order specified.  In this module, these value files will specified before the values: option generated file giving the values: in the task the final override.

Include "Fixes #93 "

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/helm.py

##### ADDITIONAL INFORMATION

```
    - name: Install nginx
      community.kubernetes.helm:
        chart_ref: helm-charts
        name: nginx
        namespace: testing
        values_files:
          - global_values.yaml
          - site_values.yaml
          - custom_values.yml

```
