### PR TITLE
k8s: Fix a bug when manifest file ends with '---'

### DIFF
--- a/changelogs/fragments/59160_handle_none_def.yml
+++ b/changelogs/fragments/59160_handle_none_def.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- raw - handle condition when definition is none (https://github.com/ansible/ansible/pull/59160).

--- a/plugins/module_utils/raw.py
+++ b/plugins/module_utils/raw.py
@@ -171,6 +171,8 @@ class KubernetesRawModule(KubernetesAnsibleModule):
 
         flattened_definitions = []
         for definition in self.resource_definitions:
+            if definition is None:
+                continue
             kind = definition.get('kind', self.kind)
             api_version = definition.get('apiVersion', self.api_version)
             if kind.endswith('List'):


### PR DESCRIPTION
##### SUMMARY

Any kubernetes manifest file ending with '---' will
generate an error when applied using 'k8s' module.

Although this may not be 'legal' YAML, this is quite frequent,
specially on helm's generated manifest files.

migrated from https://github.com/ansible/ansible/pull/59160

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/59160_handle_none_def.yml
plugins/module_utils/raw.py
