### PR TITLE
helm: Add support for K8S_AUTH_CONTEXT, K8S_AUTH_KUBECONFIG env

### DIFF
--- a/changelogs/fragments/140_kubeconfig_env.yaml
+++ b/changelogs/fragments/140_kubeconfig_env.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- helm - add support for K8S_AUTH_KUBECONFIG and K8S_AUTH_CONTEXT environment variable (https://github.com/ansible-collections/community.kubernetes/issues/140).
+- helm_info - add support for K8S_AUTH_KUBECONFIG and K8S_AUTH_CONTEXT environment variable (https://github.com/ansible-collections/community.kubernetes/issues/140).

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -98,10 +98,12 @@ options:
   kube_context:
     description:
       - Helm option to specify which kubeconfig context to use.
+      - If the value is not specified in the task, the value of environment variable C(K8S_AUTH_CONTEXT) will be used instead.
     type: str
   kubeconfig_path:
     description:
       - Helm option to specify kubeconfig path to use.
+      - If the value is not specified in the task, the value of environment variable C(K8S_AUTH_KUBECONFIG) will be used instead.
     type: path
     aliases: [ kubeconfig ]
   purge:
@@ -245,7 +247,7 @@ except ImportError:
     IMP_YAML_ERR = traceback.format_exc()
     IMP_YAML = False
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
 
 module = None
 
@@ -395,8 +397,8 @@ def main():
             # Helm options
             disable_hook=dict(type='bool', default=False),
             force=dict(type='bool', default=False),
-            kube_context=dict(type='str'),
-            kubeconfig_path=dict(type='path', aliases=['kubeconfig']),
+            kube_context=dict(type='str', fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
+            kubeconfig_path=dict(type='path', aliases=['kubeconfig'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
             purge=dict(type='bool', default=True),
             wait=dict(type='bool', default=False),
             wait_timeout=dict(type='str'),

--- a/plugins/modules/helm_info.py
+++ b/plugins/modules/helm_info.py
@@ -48,10 +48,12 @@ options:
   kube_context:
     description:
       - Helm option to specify which kubeconfig context to use.
+      - If the value is not specified in the task, the value of environment variable C(K8S_AUTH_CONTEXT) will be used instead.
     type: str
   kubeconfig_path:
     description:
       - Helm option to specify kubeconfig path to use.
+      - If the value is not specified in the task, the value of environment variable C(K8S_AUTH_KUBECONFIG) will be used instead.
     type: path
     aliases: [ kubeconfig ]
 '''
@@ -112,7 +114,7 @@ except ImportError:
     IMP_YAML_ERR = traceback.format_exc()
     IMP_YAML = False
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
 
 module = None
 
@@ -177,8 +179,8 @@ def main():
             release_namespace=dict(type='str', required=True, aliases=['namespace']),
 
             # Helm options
-            kube_context=dict(type='str'),
-            kubeconfig_path=dict(type='path', aliases=['kubeconfig']),
+            kube_context=dict(type='str', fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
+            kubeconfig_path=dict(type='path', aliases=['kubeconfig'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY

helm and helm_info modules can now use K8S_AUTH_KUBECONFIG and K8S_AUTH_KUBECONFIG
from environment variable if not specified in task.

Fixes: #140

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/140_kubeconfig_env.yaml
plugins/modules/helm.py
plugins/modules/helm_info.py
