### PR TITLE
Check if verbosity increases the length of time a job runs.

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -22,8 +22,8 @@ provisioner:
         ansible_python_interpreter: '{{ ansible_playbook_python }}'
   env:
     ANSIBLE_FORCE_COLOR: 'true'
-  options:
-    vvv: True
+  # options:
+  #   vvv: True
 scenario:
   name: default
   test_sequence:


### PR DESCRIPTION
Just testing, this is not meant to fix anything. I noticed CI can take 30+ minutes now, and I just wanted to see if maybe the verbosity setting is adding anything to that.

One thing's certain, GitHub Actions UI is almost nonresponsive when I try to follow the molecule output since there's so much of it :(﻿

The last 7 CI runs (just the Molecule job) were:

| Run Time |
| --- |
| 24:12 |
| 23:32 |
| 25:28 |
| 23:59 |
| 24:46 |
| 25:14 |
| 24:41 |

For an average run time of **24:33**.