### PR TITLE
helm_: Add context aliases for kube_context

### DIFF
--- a/changelogs/fragments/helm_context_aliases.yml
+++ b/changelogs/fragments/helm_context_aliases.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- helm - add aliases context for kube_context.
+- helm_info - add aliases context for kube_context.

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -100,6 +100,7 @@ options:
       - Helm option to specify which kubeconfig context to use.
       - If the value is not specified in the task, the value of environment variable C(K8S_AUTH_CONTEXT) will be used instead.
     type: str
+    aliases: [ context ]
   kubeconfig_path:
     description:
       - Helm option to specify kubeconfig path to use.
@@ -397,7 +398,7 @@ def main():
             # Helm options
             disable_hook=dict(type='bool', default=False),
             force=dict(type='bool', default=False),
-            kube_context=dict(type='str', fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
+            kube_context=dict(type='str', aliases=['context'], fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
             kubeconfig_path=dict(type='path', aliases=['kubeconfig'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
             purge=dict(type='bool', default=True),
             wait=dict(type='bool', default=False),

--- a/plugins/modules/helm_info.py
+++ b/plugins/modules/helm_info.py
@@ -50,6 +50,7 @@ options:
       - Helm option to specify which kubeconfig context to use.
       - If the value is not specified in the task, the value of environment variable C(K8S_AUTH_CONTEXT) will be used instead.
     type: str
+    aliases: [ context ]
   kubeconfig_path:
     description:
       - Helm option to specify kubeconfig path to use.
@@ -179,7 +180,7 @@ def main():
             release_namespace=dict(type='str', required=True, aliases=['namespace']),
 
             # Helm options
-            kube_context=dict(type='str', fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
+            kube_context=dict(type='str', aliases=['context'], fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
             kubeconfig_path=dict(type='path', aliases=['kubeconfig'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
         ),
         supports_check_mode=True,


### PR DESCRIPTION
##### SUMMARY

Added 'context' aliases for 'kube_context' in
helm and helm_info module.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/helm_context_aliases.yml
plugins/modules/helm.py
plugins/modules/helm_info.py
