### PR TITLE
Ensure check mode results are as expected

### DIFF
--- a/molecule/default/tasks/apply.yml
+++ b/molecule/default/tasks/apply.yml
@@ -324,6 +324,45 @@
             cpu: 100m
             memory: 100Mi
 
+    - name: Update the earlier deployment in check mode
+      k8s:
+        definition:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: apply-deploy
+            namespace: "{{ apply_namespace }}"
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: "{{ k8s_pod_name }}"
+            template: "{{ k8s_pod_template }}"
+        wait: yes
+        apply: yes
+      check_mode: yes
+      vars:
+        k8s_pod_name: apply-deploy
+        k8s_pod_image: gcr.io/kuar-demo/kuard-amd64:v0.10.0-purple
+        k8s_pod_service_account: apply-deploy
+        k8s_pod_ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+        k8s_pod_resources:
+          requests:
+            cpu: 50m
+          limits:
+            cpu: 50m
+            memory: 50Mi
+      register: update_deploy_check_mode
+
+    - name: Ensure check mode change took
+      assert:
+        that:
+          - update_deploy_check_mode is changed
+          - "update_deploy_check_mode.result.spec.template.spec.containers[0].image == 'gcr.io/kuar-demo/kuard-amd64:v0.10.0-purple'"
+
     - name: Update the earlier deployment
       k8s:
         definition:
@@ -354,6 +393,13 @@
           limits:
             cpu: 50m
             memory: 50Mi
+      register: update_deploy_for_real
+
+    - name: Ensure change took
+      assert:
+        that:
+          - update_deploy_for_real is changed
+          - "update_deploy_for_real.result.spec.template.spec.containers[0].image == 'gcr.io/kuar-demo/kuard-amd64:v0.10.0-purple'"
 
     - name: Remove the serviceaccount
       k8s:

--- a/molecule/default/tasks/waiter.yml
+++ b/molecule/default/tasks/waiter.yml
@@ -83,11 +83,13 @@
         k8s_pod_name: wait-ds
         k8s_pod_image: gcr.io/kuar-demo/kuard-amd64:2
       register: update_ds_check_mode
+      check_mode: yes
 
-    - name: Check that check_mode returned changed
+    - name: Check that check_mode result contains the changes
       assert:
         that:
           - update_ds_check_mode is changed
+          - "update_ds_check_mode.result.spec.template.spec.containers[0].image == 'gcr.io/kuar-demo/kuard-amd64:2'"
 
     - name: Update a daemonset
       k8s:

--- a/plugins/module_utils/raw.py
+++ b/plugins/module_utils/raw.py
@@ -309,7 +309,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                         self.fail_json(msg=msg, error=exc.status, status=exc.status, reason=exc.reason)
                 success = True
                 result['result'] = k8s_obj
-                if wait:
+                if wait and not self.check_mode:
                     success, result['result'], result['duration'] = self.wait(resource, definition, wait_sleep, wait_timeout, condition=wait_condition)
                 if existing:
                     existing = existing.to_dict()
@@ -368,7 +368,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                 match, diffs = self.diff_objects(existing.to_dict(), k8s_obj)
                 success = True
                 result['result'] = k8s_obj
-                if wait:
+                if wait and not self.check_mode:
                     success, result['result'], result['duration'] = self.wait(resource, definition, wait_sleep, wait_timeout, condition=wait_condition)
                 match, diffs = self.diff_objects(existing.to_dict(), result['result'])
                 result['changed'] = not match
@@ -396,7 +396,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
 
             success = True
             result['result'] = k8s_obj
-            if wait:
+            if wait and not self.check_mode:
                 success, result['result'], result['duration'] = self.wait(resource, definition, wait_sleep, wait_timeout, condition=wait_condition)
             match, diffs = self.diff_objects(existing.to_dict(), result['result'])
             result['changed'] = not match


### PR DESCRIPTION
##### SUMMARY
check_mode with wait updates the result based on the existing resource
which won't change with check_mode, so returns incorrect results.
Only run the wait checks in non check_mode (this also avoids the issue
of waiting for resource creation that will never happen in check mode)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
raw
