### PR TITLE
Return status in check mode

### DIFF
--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -480,9 +480,16 @@ def main():
             changed = True
 
     if module.check_mode:
+        check_status = {'values': {
+            "current": release_status['values'],
+            "proposed": release_values
+            }
+        }
+
         module.exit_json(
             changed=changed,
             command=helm_cmd,
+            status=check_status
             stdout='',
             stderr='',
         )

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -489,7 +489,7 @@ def main():
         module.exit_json(
             changed=changed,
             command=helm_cmd,
-            status=check_status
+            status=check_status,
             stdout='',
             stderr='',
         )

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -483,8 +483,7 @@ def main():
         check_status = {'values': {
             "current": release_status['values'],
             "proposed": release_values
-            }
-        }
+        }}
 
         module.exit_json(
             changed=changed,

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -482,7 +482,7 @@ def main():
     if module.check_mode:
         check_status = {'values': {
             "current": release_status['values'],
-            "proposed": release_values
+            "declared": release_values
         }}
 
         module.exit_json(


### PR DESCRIPTION
##### SUMMARY
In check mode, it is useful to know both what the current values of the release are, and the proposed values of the release based on the state of the playbook.

Addresses : #188 

##### ISSUE TYPE
- Feature Pull Request

##### Questions

- `current` and `proposed` feel a little off in terms of ansible norms, any suggestions for something "better"?
- What would be the best way to address this in the documentation? Maybe adding another values('check_mode') key?

