### PR TITLE
kubectl: correct usage in console

### DIFF
--- a/changelogs/fragments/200_kubectl_fix.yml
+++ b/changelogs/fragments/200_kubectl_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- kubectl plugin - correct console log (https://github.com/ansible-collections/community.kubernetes/issues/200).

--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -228,7 +228,8 @@ class Connection(ConnectionBase):
     def _build_exec_cmd(self, cmd):
         """ Build the local kubectl exec command to run cmd on remote_host
         """
-        local_cmd = censored_local_cmd = [self.transport_cmd]
+        local_cmd = [self.transport_cmd]
+        censored_local_cmd = [self.transport_cmd]
 
         # Build command options based on doc string
         doc_yaml = AnsibleLoader(self.documentation).get_single_data()


### PR DESCRIPTION
##### SUMMARY

kubectl exec is printed twice in console log.

Fixes: #200

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/200_kubectl_fix.yml
plugins/connection/kubectl.py
