### PR TITLE
PR #196 follow-up: Adjust stale bot exemptLabels.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,10 +16,10 @@ onlyLabels: []
 # Issues or Pull Requests with these labels will never be considered stale. Set
 # to `[]` to disable
 exemptLabels:
-  - pinned
   - security
   - planned
   - priority/critical
+  - lifecycle/frozen
   - verified
 
 # Set to true to ignore issues in a project (defaults to false)


### PR DESCRIPTION
Follow-up to PR #196 for Issue #53: Add lifecycle/frozen label and remove pinned label from stale bot exemptLabels configuration, as per discussion with @tima and @fabianvf.﻿
