### PR TITLE
Set the connection plugin and transport separately, add tests

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -30,3 +30,87 @@
 
   roles:
     - helm
+
+  post_tasks:
+    - name: Ensure namespace exists
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: inventory
+
+    - name: Add a deployment
+      k8s:
+        definition:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: inventory
+            namespace: inventory
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: "{{ k8s_pod_name }}"
+            template: "{{ k8s_pod_template }}"
+        wait: yes
+        wait_timeout: 120
+      vars:
+        k8s_pod_name: inventory
+        k8s_pod_image: python
+        k8s_pod_command:
+          - python
+          - '-m'
+          - http.server
+        k8s_pod_env:
+          - name: TEST
+            value: test
+
+    - meta: refresh_inventory
+
+- name: Verify inventory and connection plugins
+  hosts: namespace_inventory_pods
+  gather_facts: no
+
+  vars:
+    file_content: |
+      Hello world
+
+  tasks:
+    - name: End play if host not running (TODO should we not add these to the inventory?)
+      meta: end_host
+      when: pod_phase != "Running"
+
+    - debug: var=hostvars
+    - setup:
+
+    - debug: var=ansible_facts
+
+    - name: Assert the TEST environment variable was retrieved
+      assert:
+        that: ansible_facts.env.TEST == 'test'
+
+    - name: Copy a file into the host
+      copy:
+        content: '{{ file_content }}'
+        dest: /tmp/test_file
+
+    - name: Retrieve the file from the host
+      slurp:
+        src: /tmp/test_file
+      register: slurped_file
+
+    - name: Assert the file content matches expectations
+      assert:
+        that: (slurped_file.content|b64decode) == file_content
+
+- name: Delete inventory namespace
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: Remove inventory namespace
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: inventory
+        state: absent

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,8 +15,13 @@ platforms:
 provisioner:
   name: ansible
   log: true
+  config_options:
+    inventory:
+      enable_plugins: community.kubernetes.k8s
   lint: {}
   inventory:
+    hosts:
+      plugin: community.kubernetes.k8s
     host_vars:
       localhost:
         ansible_python_interpreter: '{{ ansible_playbook_python }}'

--- a/molecule/default/vars/main.yml
+++ b/molecule/default/vars/main.yml
@@ -17,6 +17,7 @@ k8s_pod_spec:
             - /bin/true
       resources: "{{ k8s_pod_resources }}"
       ports: "{{ k8s_pod_ports }}"
+      env: "{{ k8s_pod_env }}"
 
 
 k8s_pod_service_account: default
@@ -29,6 +30,8 @@ k8s_pod_resources:
 k8s_pod_command: []
 
 k8s_pod_ports: []
+
+k8s_pod_env: []
 
 k8s_pod_template:
   metadata: "{{ k8s_pod_metadata }}"

--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -143,6 +143,7 @@ class K8sInventoryException(Exception):
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleMixin):
     NAME = 'community.kubernetes.k8s'
 
+    connection_plugin = 'kubectl'
     transport = 'kubectl'
 
     def parse(self, inventory, loader, path, cache=True):
@@ -276,7 +277,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
                     self.inventory.set_variable(container_name, 'container_state', 'Waiting')
                 self.inventory.set_variable(container_name, 'container_ready', container.ready)
                 self.inventory.set_variable(container_name, 'ansible_remote_tmp', '/tmp/')
-                self.inventory.set_variable(container_name, 'ansible_connection', self.transport)
+                self.inventory.set_variable(container_name, 'ansible_connection', self.connection_plugin)
                 self.inventory.set_variable(container_name, 'ansible_{0}_pod'.format(self.transport),
                                             pod_name)
                 self.inventory.set_variable(container_name, 'ansible_{0}_container'.format(self.transport),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The inventory plugin now properly sets the connection plugin to `community.kubernetes.kubectl` instead of just `kubectl`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/inventory/k8s.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
