### PR TITLE
Add execution environment metadata

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,1 @@
+kubernetes-client [platform:fedora]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openshift>=0.6.2
+requests-oauthlib


### PR DESCRIPTION
##### SUMMARY
We are building tooling for building container images with necessary python & system requirements to use content inside of collections.

https://github.com/ansible/ansible-builder

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION
The specific case here was a bit tricky, because in RHEL8-like platforms, the repos that provide `kubernetes-client` were not available. We plan to use this as a part of AWX, we make use of the connection plugin, and thus need the `kubectl` CLI.

The solution was that @shanemcd changed the base image from centos8 to fedora https://github.com/ansible/ansible-runner/pull/502. This will install in fedora out-of-the-box. The way that `bindep` works, it just won't try to install it unless the platform is fedora. This is the only approach I came up with that respects the philosophy of bindep, in that there's a universal truth - "are you on fedora? great, then dnf install this". People on other platforms can get it with more steps, but we don't want to be opinionated about _how_ at this early stage.

Other requirements came from the individual module/plugin `requirements:` entry, which I scraped here:

https://github.com/AlanCoding/collection-dependencies-demo/blob/dd568760a0ccc8fe5c38ca149e78e62ca6af50bb/sniff_req/discovered.json#L599-L606

Similar to the issue with `kubectl`, things which are more complex installs by the features in `ansible-builder` right now, so we can't add `helm`.
