### PR TITLE
Refactor inventory plugin

### DIFF
--- a/changelogs/fragments/refactor_k8s_inventory.yml
+++ b/changelogs/fragments/refactor_k8s_inventory.yml
@@ -1,0 +1,8 @@
+breaking_changes:
+- k8s inventory - no longer adds services to lists of hosts (https://github.com/ansible-collections/community.kubernetes/pull/217).
+- k8s inventory - removed the ``*_pods`` groups, as pods are the only valid hosts anyway (https://github.com/ansible-collections/community.kubernetes/pull/217).
+minor_changes:
+- k8s inventory - group names are now sanitized (https://github.com/ansible-collections/community.kubernetes/pull/217).
+- k8s inventory - add new groups for Deployments, Daemonsets and StatefulSets, allowing
+  easy access to pods that are created by those resources (https://github.com/ansible-collections/community.kubernetes/pull/217).
+- k8s inventory - move extract_selector method to common (https://github.com/ansible-collections/community.kubernetes/pull/217).

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -40,7 +40,7 @@
       k8s:
         api_version: v1
         kind: Namespace
-        name: inventory
+        name: inventory-ns
 
     - name: Add a deployment
       k8s:
@@ -49,7 +49,7 @@
           kind: Deployment
           metadata:
             name: inventory
-            namespace: inventory
+            namespace: inventory-ns
           spec:
             replicas: 1
             selector:
@@ -72,7 +72,7 @@
     - meta: refresh_inventory
 
 - name: Verify inventory and connection plugins
-  hosts: namespace_inventory_deployment_inventory
+  hosts: namespace_inventory_ns_deployment_inventory
   gather_facts: yes
 
   vars:
@@ -109,5 +109,5 @@
       k8s:
         api_version: v1
         kind: Namespace
-        name: inventory
+        name: inventory-ns
         state: absent

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -72,21 +72,14 @@
     - meta: refresh_inventory
 
 - name: Verify inventory and connection plugins
-  hosts: namespace_inventory_pods
-  gather_facts: no
+  hosts: namespace_inventory_deployment_inventory
+  gather_facts: yes
 
   vars:
     file_content: |
       Hello world
 
   tasks:
-    - name: End play if host not running (TODO should we not add these to the inventory?)
-      meta: end_host
-      when: pod_phase != "Running"
-
-    - debug: var=hostvars
-    - setup:
-
     - debug: var=ansible_facts
 
     - name: Assert the TEST environment variable was retrieved

--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -154,6 +154,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
     connection_plugin = "community.kubernetes.kubectl"
     transport = "kubectl"
 
+    PARENT_RESOURCES = [
+        {'api_version': 'apps/v1', 'kind': 'Deployment'},
+        {'api_version': 'apps/v1', 'kind': 'DaemonSet'},
+        {'api_version': 'apps/v1', 'kind': 'StatefulSet'},
+    ]
+
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)
         cache_key = self._get_cache_prefix(path)
@@ -238,10 +244,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
 
     def get_pods_from_parents(self, client, name, namespace, namespace_group):
 
+<<<<<<< HEAD
         v1_pods = client.resources.get(api_version="v1", kind="Pod")
         for kind in ["Deployment", "Daemonset", "StatefulSet"]:
             try:
                 resource = client.resources.get(api_version="apps/v1", kind=kind)
+=======
+        v1_pods = client.resources.get(api_version='v1', kind='Pod')
+        for item in self.PARENT_RESOURCES:
+            try:
+                resource = client.resources.get(api_version=item['api_version'], kind=item['kind'])
+>>>>>>> Make parent resources more easily configurable
                 instances = resource.get(namespace=namespace)
             except Exception:
                 # TODO Could be expected due to RBAC or odd cluster, maybe should log a warning or something?
@@ -263,6 +276,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
                     )
                 except DynamicApiError as exc:
                     self.display.debug(exc)
+<<<<<<< HEAD
                     raise K8sInventoryException(
                         "Error fetching Pod list: %s" % format_dynamic_api_exc(exc)
                     )
@@ -272,6 +286,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable, K8sAnsibleM
                         namespace_group, kind.lower(), instance.metadata.name
                     )
                 )
+=======
+                    raise K8sInventoryException('Error fetching Pod list: %s' % format_dynamic_api_exc(exc))
+
+                instance_group = self.sanitize('{0}_{1}_{2}'.format(namespace_group, item['kind'].lower(), instance.metadata.name))
+>>>>>>> Make parent resources more easily configurable
                 self.inventory.add_group(instance_group)
                 self.inventory.add_child(namespace_group, instance_group)
 


### PR DESCRIPTION
##### SUMMARY
Inventory plugin only adds valid hosts and groups
    
- No longer adds services to lists of hosts
- Group names are now sanitized
- Removed the `*_pods` groups, as pods are the only valid hosts anyway
- Add new groups for Deployments, Daemonsets and StatefulSets, allowing
  easy access to pods that are created by those resources
- Move extract_selector method to common


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/k8s.py

##### ADDITIONAL INFORMATION
Technically modifying the group names to be valid could be considered a breaking change, though it's probably a bug that they weren't in the first place.