### PR TITLE
Replace KubernetesAnsibleModule class with dummy class

### DIFF
--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -24,7 +24,7 @@ import os
 import traceback
 
 
-from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native
 
@@ -416,3 +416,17 @@ class K8sAnsibleMixin(object):
             if self.namespace:
                 implicit_definition['metadata']['namespace'] = self.namespace
             self.resource_definitions = [implicit_definition]
+
+
+class KubernetesAnsibleModule(AnsibleModule, K8sAnsibleMixin):
+    # NOTE: This class KubernetesAnsibleModule is deprecated in favor of
+    #       class K8sAnsibleMixin and will be removed 2.0.0 release.
+    #       Please use K8sAnsibleMixin instead.
+
+    def __init__(self, *args, **kwargs):
+        kwargs['argument_spec'] = self.argspec
+        AnsibleModule.__init__(self, *args, **kwargs)
+        K8sAnsibleMixin.__init__(self, *args, **kwargs)
+
+        self.warn("class KubernetesAnsibleModule is deprecated"
+                  " and will be removed in 2.0.0. Please use K8sAnsibleMixin instead.")

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -156,6 +156,15 @@ AUTH_ARG_MAP = {
 
 class K8sAnsibleMixin(object):
 
+    def __init__(self, *args, **kwargs):
+        if not HAS_K8S_MODULE_HELPER:
+            self.fail_json(msg=missing_required_lib('openshift'), exception=K8S_IMP_ERR,
+                           error=to_native(k8s_import_exception))
+        self.openshift_version = openshift.__version__
+
+        if not HAS_YAML:
+            self.fail_json(msg=missing_required_lib("PyYAML"), exception=YAML_IMP_ERR)
+
     def get_api_client(self, **auth_params):
         auth_params = auth_params or getattr(self, 'params', {})
         auth = {}
@@ -283,28 +292,6 @@ class K8sAnsibleMixin(object):
             self.warn('No meaningful diff was generated, but the API may not be idempotent (only metadata.generation or metadata.resourceVersion were changed)')
 
         return True, result
-
-
-class KubernetesAnsibleModule(AnsibleModule, K8sAnsibleMixin):
-    resource_definition = None
-    api_version = None
-    kind = None
-
-    def __init__(self, *args, **kwargs):
-
-        kwargs['argument_spec'] = self.argspec
-        AnsibleModule.__init__(self, *args, **kwargs)
-
-        if not HAS_K8S_MODULE_HELPER:
-            self.fail_json(msg=missing_required_lib('openshift'), exception=K8S_IMP_ERR,
-                           error=to_native(k8s_import_exception))
-        self.openshift_version = openshift.__version__
-
-        if not HAS_YAML:
-            self.fail_json(msg=missing_required_lib("PyYAML"), exception=YAML_IMP_ERR)
-
-    def execute_module(self):
-        raise NotImplementedError()
 
     def fail(self, msg=None):
         self.fail_json(msg=msg)

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -24,7 +24,7 @@ import os
 import traceback
 
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native
 

--- a/plugins/module_utils/raw.py
+++ b/plugins/module_utils/raw.py
@@ -25,10 +25,10 @@ import sys
 import traceback
 
 from ansible.module_utils.basic import missing_required_lib, AnsibleModule
-from ansible_collections.community.kubernetes.plugins.module_utils.common import (
-    AUTH_ARG_SPEC, COMMON_ARG_SPEC, RESOURCE_ARG_SPEC, NAME_ARG_SPEC, K8sAnsibleMixin)
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import dict_merge
+from ansible_collections.community.kubernetes.plugins.module_utils.common import (
+    AUTH_ARG_SPEC, COMMON_ARG_SPEC, RESOURCE_ARG_SPEC, NAME_ARG_SPEC, K8sAnsibleMixin)
 
 
 try:
@@ -105,6 +105,7 @@ class KubernetesRawModule(K8sAnsibleMixin):
         )
 
         self.module = module
+        self.check_mode = self.module.check_mode
         self.params = self.module.params
         self.fail_json = self.module.fail_json
         self.fail = self.module.fail_json

--- a/plugins/module_utils/scale.py
+++ b/plugins/module_utils/scale.py
@@ -21,8 +21,9 @@ __metaclass__ = type
 
 import copy
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC, RESOURCE_ARG_SPEC, NAME_ARG_SPEC
-from ansible_collections.community.kubernetes.plugins.module_utils.common import KubernetesAnsibleModule
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.kubernetes.plugins.module_utils.common import (
+    AUTH_ARG_SPEC, RESOURCE_ARG_SPEC, NAME_ARG_SPEC, K8sAnsibleMixin)
 
 try:
     from openshift.dynamic.exceptions import NotFoundError
@@ -39,7 +40,7 @@ SCALE_ARG_SPEC = {
 }
 
 
-class KubernetesAnsibleScaleModule(KubernetesAnsibleModule):
+class KubernetesAnsibleScaleModule(K8sAnsibleMixin):
 
     def __init__(self, k8s_kind=None, *args, **kwargs):
         self.client = None
@@ -49,10 +50,19 @@ class KubernetesAnsibleScaleModule(KubernetesAnsibleModule):
             ('resource_definition', 'src'),
         ]
 
-        KubernetesAnsibleModule.__init__(self, *args,
-                                         mutually_exclusive=mutually_exclusive,
-                                         supports_check_mode=True,
-                                         **kwargs)
+        module = AnsibleModule(
+            argument_spec=self.argspec,
+            mutually_exclusive=mutually_exclusive,
+            supports_check_mode=True,
+        )
+
+        self.module = module
+        self.params = self.module.params
+        self.fail_json = self.module.fail_json
+        self.fail = self.module.fail_json
+        self.exit_json = self.module.exit_json
+        super(KubernetesAnsibleScaleModule, self).__init__()
+
         self.kind = k8s_kind or self.params.get('kind')
         self.api_version = self.params.get('api_version')
         self.name = self.params.get('name')

--- a/plugins/module_utils/scale.py
+++ b/plugins/module_utils/scale.py
@@ -58,6 +58,7 @@ class KubernetesAnsibleScaleModule(K8sAnsibleMixin):
 
         self.module = module
         self.params = self.module.params
+        self.check_mode = self.module.check_mode
         self.fail_json = self.module.fail_json
         self.fail = self.module.fail_json
         self.exit_json = self.module.exit_json

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -147,6 +147,7 @@ class KubernetesInfoModule(K8sAnsibleMixin):
         self.module = module
         self.params = self.module.params
         self.fail_json = self.module.fail_json
+        self.exit_json = self.module.exit_json
         super(KubernetesInfoModule, self).__init__()
 
     def execute_module(self):

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -130,17 +130,24 @@ resources:
       type: dict
 '''
 
-
-from ansible_collections.community.kubernetes.plugins.module_utils.common import KubernetesAnsibleModule, AUTH_ARG_SPEC
 import copy
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.kubernetes.plugins.module_utils.common import (
+    K8sAnsibleMixin, AUTH_ARG_SPEC)
 
-class KubernetesInfoModule(KubernetesAnsibleModule):
+
+class KubernetesInfoModule(K8sAnsibleMixin):
 
     def __init__(self, *args, **kwargs):
-        KubernetesAnsibleModule.__init__(self, *args,
-                                         supports_check_mode=True,
-                                         **kwargs)
+        module = AnsibleModule(
+            argument_spec=self.argspec,
+            supports_check_mode=True,
+        )
+        self.module = module
+        self.params = self.module.params
+        self.fail_json = self.module.fail_json
+        super(KubernetesInfoModule, self).__init__()
 
     def execute_module(self):
         self.client = self.get_api_client()

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -121,8 +121,6 @@ from ansible_collections.community.kubernetes.plugins.module_utils.common import
 class KubernetesLogModule(K8sAnsibleMixin):
 
     def __init__(self):
-        super(KubernetesLogModule, self).__init__()
-
         module = AnsibleModule(
             argument_spec=self.argspec,
             supports_check_mode=True,
@@ -132,6 +130,7 @@ class KubernetesLogModule(K8sAnsibleMixin):
         self.fail_json = self.module.fail_json
         self.fail = self.module.fail_json
         self.exit_json = self.module.exit_json
+        super(KubernetesLogModule, self).__init__()
 
     @property
     def argspec(self):

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -111,18 +111,27 @@ log_lines:
 
 import copy
 
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import PY2
 
-from ansible_collections.community.kubernetes.plugins.module_utils.common import KubernetesAnsibleModule
-from ansible_collections.community.kubernetes.plugins.module_utils.common import AUTH_ARG_SPEC, NAME_ARG_SPEC
+from ansible_collections.community.kubernetes.plugins.module_utils.common import (
+    K8sAnsibleMixin, AUTH_ARG_SPEC, NAME_ARG_SPEC)
 
 
-class KubernetesLogModule(KubernetesAnsibleModule):
+class KubernetesLogModule(K8sAnsibleMixin):
 
-    def __init__(self, *args, **kwargs):
-        KubernetesAnsibleModule.__init__(self, *args,
-                                         supports_check_mode=True,
-                                         **kwargs)
+    def __init__(self):
+        super(KubernetesLogModule, self).__init__()
+
+        module = AnsibleModule(
+            argument_spec=self.argspec,
+            supports_check_mode=True,
+        )
+        self.module = module
+        self.params = self.module.params
+        self.fail_json = self.module.fail_json
+        self.fail = self.module.fail_json
+        self.exit_json = self.module.exit_json
 
     @property
     def argspec(self):


### PR DESCRIPTION
##### SUMMARY

* Make a AnsibleMixin parent class for every module
* Remove KubernetesAnsibleModule class
* Modified k8s_log

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/common.py
plugins/modules/k8s_log.py
