### PR TITLE
Do not mark task as changed when diff is irrelevant

### DIFF
--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -256,14 +256,30 @@ class K8sAnsibleMixin(object):
             self.fail(msg="Error loading resource_definition: {0}".format(exc))
         return result
 
-    @staticmethod
-    def diff_objects(existing, new):
+    def diff_objects(self, existing, new):
         result = dict()
         diff = recursive_diff(existing, new)
-        if diff:
-            result['before'] = diff[0]
-            result['after'] = diff[1]
-        return not diff, result
+        if not diff:
+            return True, result
+
+        result['before'] = diff[0]
+        result['after'] = diff[1]
+
+        # If only metadata.generation and metadata.resourceVersion changed, ignore it
+        ignored_keys = set(['generation', 'resourceVersion'])
+
+        if list(result['after'].keys()) != ['metadata'] or list(result['before'].keys()) != ['metadata']:
+            return False, result
+
+        if not set(result['after']['metadata'].keys()).issubset(ignored_keys):
+            return False, result
+        if not set(result['before']['metadata'].keys()).issubset(ignored_keys):
+            return False, result
+
+        if hasattr(self, 'warn'):
+            self.warn('No meaningful diff was generated, but the API may not be idempotent (only metadata.generation or metadata.resourceVersion were changed)')
+
+        return True, result
 
 
 class KubernetesAnsibleModule(AnsibleModule, K8sAnsibleMixin):


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the diff contains changes only to the fields `metadata.generation`
or `metadata.resourceVersion`, do not mark the task as changed. Instead,
   emit a warning highlighting that the API itself may not be
   idempotent, but that there was no meaningful difference between the
   desired and actual state of the resource.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/k8s.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
