### PR TITLE
SelfSubjectAccessReviews now work with the k8s module

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -28,6 +28,7 @@
     - include_tasks: tasks/exec.yml
     - include_tasks: tasks/log.yml
     - include_tasks: tasks/cluster_info.yml
+    - include_tasks: tasks/access_review.yml
 
   roles:
     - helm

--- a/molecule/default/tasks/access_review.yml
+++ b/molecule/default/tasks/access_review.yml
@@ -17,7 +17,6 @@
   assert:
     that:
       - can_i_create_namespaces is successful
-      - (can_i_create_namespaces.resources | length) == 1
-      - can_i_create_namespaces.resources.0.status is defined
-      - can_i_create_namespaces.resources.0.status.allowed is defined
-      - can_i_create_namespaces.resources.0.status.allowed
+      - can_i_create_namespaces.result.status is defined
+      - can_i_create_namespaces.result.status.allowed is defined
+      - can_i_create_namespaces.result.status.allowed

--- a/molecule/default/tasks/access_review.yml
+++ b/molecule/default/tasks/access_review.yml
@@ -1,0 +1,23 @@
+---
+- name: Create a SelfSubjectAccessReview resource
+  register: can_i_create_namespaces
+  ignore_errors: yes
+  k8s:
+    state: present
+    definition:
+      apiVersion: authorization.k8s.io/v1
+      kind: SelfSubjectAccessReview
+      spec:
+        resourceAttributes:
+          group: v1
+          resource: Namespace
+          verb: create
+
+- name: Assert that the SelfSubjectAccessReview request succeded
+  assert:
+    that:
+      - can_i_create_namespaces is successful
+      - (can_i_create_namespaces.resources | length) == 1
+      - can_i_create_namespaces.resources.0.status is defined
+      - can_i_create_namespaces.resources.0.status.allowed is defined
+      - can_i_create_namespaces.resources.0.status.allowed

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -38,7 +38,7 @@ try:
     from openshift.dynamic import DynamicClient
     from openshift.dynamic.exceptions import (
         ResourceNotFoundError, ResourceNotUniqueError, NotFoundError, DynamicApiError,
-        ConflictError, ForbiddenError)
+        ConflictError, ForbiddenError, MethodNotAllowedError)
     HAS_K8S_MODULE_HELPER = True
     k8s_import_exception = None
 except ImportError as e:
@@ -610,7 +610,7 @@ class K8sAnsibleMixin(object):
             if namespace:
                 params['namespace'] = namespace
             existing = resource.get(**params)
-        except NotFoundError:
+        except (NotFoundError, MethodNotAllowedError):
             # Remove traceback so that it doesn't show up in later failures
             try:
                 sys.exc_clear()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the initial `GET` request fails with a `405 MethodNotAllowed`, we now treat it as if the resource does not exist. This allows resources that do not support the `GET` verb to properly work (albeit not idempotently). This allows users to interact with the `SelfSubjectAccessReview` APIs.

Fixes #234 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
