### PR TITLE
Fix default configuration getter in client v12.0.0

### DIFF
--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -252,7 +252,12 @@ class K8sAnsibleMixin(object):
                     self.fail(msg='Failed to load kubeconfig due to %s' % to_native(err))
 
         # Override any values in the default configuration with Ansible parameters
-        configuration = kubernetes.client.Configuration()
+        # As of kubernetes-client v12.0.0, get_default_copy() is required here
+        try:
+            configuration = kubernetes.client.Configuration().get_default_copy()
+        except AttributeError:
+            configuration = kubernetes.client.Configuration()
+
         for key, value in iteritems(auth):
             if key in AUTH_ARG_MAP.keys() and value is not None:
                 if key == 'api_key':

--- a/tests/integration/targets/kubernetes/tasks/main.yml
+++ b/tests/integration/targets/kubernetes/tasks/main.yml
@@ -51,6 +51,27 @@
     state: absent
   no_log: yes
 
+# Test new config getter (kubernetes==12.0.0)
+
+- pip:
+    name:
+      - kubernetes==12.0.0
+      - openshift>=0.9.2
+      - coverage
+    virtualenv: "{{ virtualenv }}"
+    virtualenv_command: "{{ virtualenv_command }}"
+    virtualenv_site_packages: no
+
+- include_tasks: new_config_getter.yml
+  vars:
+    ansible_python_interpreter: "{{ virtualenv_interpreter }}"
+    playbook_namespace: ansible-test-k8s-config-getter
+
+- file:
+    path: "{{ virtualenv }}"
+    state: absent
+  no_log: yes
+
 # Test graceful failure for older versions of openshift
 
 - pip:

--- a/tests/integration/targets/kubernetes/tasks/new_config_getter.yml
+++ b/tests/integration/targets/kubernetes/tasks/new_config_getter.yml
@@ -1,0 +1,16 @@
+---
+- block:
+    - name: Create a namespace
+      k8s:
+        name: "{{ playbook_namespace }}"
+        kind: Namespace
+
+    - name: Delete namespace
+      k8s:
+        state: absent
+        definition:
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: "{{ playbook_namespace }}"
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Use get_default_copy() to load the default configuration. Fixes #273 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s module

##### ADDITIONAL INFORMATION
See also kubernetes-client/python#1284
