### PR TITLE
test: older_openshift_fail.yml fails with py3.7+

### DIFF
--- a/tests/integration/targets/kubernetes/tasks/main.yml
+++ b/tests/integration/targets/kubernetes/tasks/main.yml
@@ -73,20 +73,26 @@
   no_log: yes
 
 # Test graceful failure for older versions of openshift
+- name: Get the Python version
+  setup:
+    filter: ansible_python_version
 
-- pip:
-    name:
-      - openshift==0.6.0
-      - kubernetes==6.0.0
-      - coverage
-    virtualenv: "{{ virtualenv }}"
-    virtualenv_command: "{{ virtualenv_command }}"
-    virtualenv_site_packages: no
+- when: ansible_python_version is version('3.7', '<')
+  block:
+    - pip:
+        name:
+          - openshift==0.6.0
+          - kubernetes==6.0.0
+          - coverage
+        virtualenv: "{{ virtualenv }}"
+        virtualenv_command: "{{ virtualenv_command }}"
+        virtualenv_site_packages: no
 
-- include_tasks: older_openshift_fail.yml
-  vars:
-    ansible_python_interpreter: "{{ virtualenv_interpreter }}"
-    playbook_namespace: ansible-test-k8s-older-openshift
+    - include_tasks: older_openshift_fail.yml
+      vars:
+        ansible_python_interpreter: "{{ virtualenv_interpreter }}"
+        playbook_namespace: ansible-test-k8s-older-openshift
+
 
 - file:
     path: "{{ virtualenv }}"


### PR DESCRIPTION
The `older_openshift_fail.yml` test playbook fails with Python 3.7
because the old `kubernetes.client.apis.admissionregistration_api`
module uses the new `async` keyword as a function parameter name.

From: https://docs.python.org/3/whatsnew/3.7.html

Backwards incompatible syntax changes:

    `async` and `await` are now reserved keywords.

In this case, we get a `SyntaxError` exception instead of the expected
`Failed to import the required Python library (openshift >= 0.7.2)`.