### PR TITLE
molecule: use the new charts repository

### DIFF
--- a/molecule/default/roles/helm/defaults/main.yml
+++ b/molecule/default/roles/helm/defaults/main.yml
@@ -9,7 +9,7 @@ tiller_cluster_role: cluster-admin
 chart_test: "nginx-ingress"
 chart_test_version: 1.32.0
 chart_test_version_upgrade: 1.33.0
-chart_test_repo: "https://kubernetes-charts.storage.googleapis.com"
+chart_test_repo: "https://charts.helm.sh/stable"
 chart_test_git_repo: "http://github.com/helm/charts.git"
 chart_test_values:
   revisionHistoryLimit: 0

--- a/molecule/default/roles/helm/tasks/tests_chart/from_url.yml
+++ b/molecule/default/roles/helm/tasks/tests_chart/from_url.yml
@@ -3,5 +3,7 @@
   include_tasks: "../tests_chart.yml"
   vars:
     source: url
-    chart_source: "{{ chart_test_repo }}/{{ chart_test }}-{{ chart_test_version }}.tgz"
-    chart_source_upgrade: "{{ chart_test_repo }}/{{ chart_test }}-{{ chart_test_version_upgrade }}.tgz"
+    chart_test: "fission"
+    cjart_test_version: "0.10.0"
+    chart_source: "https://github.com/fission/fission/releases/download/0.10.0/fission-all-0.10.0.tgz"
+    chart_source_upgrade: "https://github.com/fission/fission/releases/download/0.11.2/fission-all-0.11.2.tgz"


### PR DESCRIPTION
molecule: use the new charts repository

Since October, 26th, the sable repository has a new location.
See: https://helm.sh/blog/new-location-stable-incubator-charts/

Without this change, the test-suite fails because of the following
error:

```
$ `helm repo add test_helm_repo https://kubernetes-charts.storage.googleapis.com`
Error: repo "https://kubernetes-charts.storage.googleapis.com" is no longer available; try "https://charts.helm.sh/stable" instead
```