### PR TITLE
molecule: use the new charts repository

### DIFF
--- a/molecule/default/roles/helm/defaults/main.yml
+++ b/molecule/default/roles/helm/defaults/main.yml
@@ -9,7 +9,7 @@ tiller_cluster_role: cluster-admin
 chart_test: "nginx-ingress"
 chart_test_version: 1.32.0
 chart_test_version_upgrade: 1.33.0
-chart_test_repo: "https://kubernetes-charts.storage.googleapis.com"
+chart_test_repo: "https://charts.helm.sh/stable"
 chart_test_git_repo: "http://github.com/helm/charts.git"
 chart_test_values:
   revisionHistoryLimit: 0


### PR DESCRIPTION
Since October, 26th, the sable repository has a new location.
See: https://helm.sh/blog/new-location-stable-incubator-charts/

Without this change, the test-suite fails because of the following
error:

```
$ `helm repo add test_helm_repo https://kubernetes-charts.storage.googleapis.com`
Error: repo "https://kubernetes-charts.storage.googleapis.com" is no longer available; try "https://charts.helm.sh/stable" instead
```