### PR TITLE
Use runtime.yml for action plugin redirection

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -17,6 +17,35 @@ action_groups:
     - k8s_service
 
 plugin_routing:
+  action:
+    helm:
+      redirect: community.kubernetes.k8s_info
+    helm_info:
+      redirect: community.kubernetes.k8s_info
+    helm_plugin:
+      redirect: community.kubernetes.k8s_info
+    helm_plugin_info:
+      redirect: community.kubernetes.k8s_info
+    helm_repository:
+      redirect: community.kubernetes.k8s_info
+    k8s:
+      redirect: community.kubernetes.k8s_info
+    k8s_auth:
+      redirect: community.kubernetes.k8s_info
+    k8s_cluster_info:
+      redirect: community.kubernetes.k8s_info
+    k8s_event_info:
+      redirect: community.kubernetes.k8s_info
+    k8s_exec:
+      redirect: community.kubernetes.k8s_info
+    k8s_log:
+      redirect: community.kubernetes.k8s_info
+    k8s_rollback:
+      redirect: community.kubernetes.k8s_info
+    k8s_scale:
+      redirect: community.kubernetes.k8s_info
+    k8s_service:
+      redirect: community.kubernetes.k8s_info
   modules:
     # k8s_facts was originally slated for removal in Ansible 2.13.
     k8s_facts:

--- a/plugins/action/helm.py
+++ b/plugins/action/helm.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/helm_info.py
+++ b/plugins/action/helm_info.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/helm_plugin.py
+++ b/plugins/action/helm_plugin.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/helm_plugin_info.py
+++ b/plugins/action/helm_plugin_info.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/helm_repository.py
+++ b/plugins/action/helm_repository.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/k8s.py
+++ b/plugins/action/k8s.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/k8s_auth.py
+++ b/plugins/action/k8s_auth.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/k8s_exec.py
+++ b/plugins/action/k8s_exec.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/k8s_log.py
+++ b/plugins/action/k8s_log.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/k8s_scale.py
+++ b/plugins/action/k8s_scale.py
@@ -1,1 +1,0 @@
-k8s_info.py

--- a/plugins/action/k8s_service.py
+++ b/plugins/action/k8s_service.py
@@ -1,1 +1,0 @@
-k8s_info.py


### PR DESCRIPTION
##### SUMMARY

Previously, kubernetes collection used symlink for
action plugin redirection. It is problematic when FQCN
is not provided.
Using runtime.yml to redirect the action plugin.

Fixes: #278

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meta/runtime.yml
plugins/action/helm.py
plugins/action/helm_info.py
plugins/action/helm_plugin.py
plugins/action/helm_plugin_info.py
plugins/action/helm_repository.py
plugins/action/k8s.py
plugins/action/k8s_auth.py
plugins/action/k8s_exec.py
plugins/action/k8s_log.py
plugins/action/k8s_scale.py
plugins/action/k8s_service.py
