### PR TITLE
molecule: clone the chart repos with depth=1

### DIFF
--- a/molecule/default/roles/helm/tasks/tests_chart/from_local_path.yml
+++ b/molecule/default/roles/helm/tasks/tests_chart/from_local_path.yml
@@ -4,12 +4,14 @@
     repo: "{{ chart_test_git_repo }}"
     dest: /tmp/helm_test_repo
     version: 631eb8413f6728962439488f48d7d6fbb954a6db
+    depth: 1
 
 - name: Git clone stable repo upgrade
   git:
     repo: "{{ chart_test_git_repo }}"
     dest: /tmp/helm_test_repo_upgrade
     version: d37b5025ffc8be49699898369fbb59661e2a8ffb
+    depth: 1
 
 - name: Install Chart from local path
   include_tasks: "../tests_chart.yml"


### PR DESCRIPTION
We only need to checkout one specific commit, no need to retrieve the
whole repository.

The whole repository is 282.34MiB, with `depth=1`, we only retrieve
4.74MiB. Since we clone the repositry 3 times, we save =~ 800MiB per
run.

```
$ time git clone http://github.com/helm/charts.git regular
Cloning into 'regular'...
warning: redirecting to https://github.com/helm/charts.git/
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 127070 (delta 0), reused 3 (delta 0), pack-reused 127061
Receiving objects: 100% (127070/127070), 282.34 MiB | 49.89 MiB/s, done.
Resolving deltas: 100% (85717/85717), done.

real    0m9.514s
user    0m11.197s
sys     0m1.579s
$ time git clone --depth=1 http://github.com/helm/charts.git depth1
Cloning into 'depth1'...
warning: redirecting to https://github.com/helm/charts.git/
remote: Enumerating objects: 6535, done.
remote: Counting objects: 100% (6535/6535), done.
remote: Compressing objects: 100% (5486/5486), done.
remote: Total 6535 (delta 2261), reused 2377 (delta 866), pack-reused 0
Receiving objects: 100% (6535/6535), 4.74 MiB | 10.17 MiB/s, done.
Resolving deltas: 100% (2261/2261), done.

real    0m2.671s
user    0m0.498s
sys     0m0.207s
```