### PR TITLE
test: reduce the cluster's min number of pods

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,9 +16,9 @@
         kind: Pod
       register: pod_list
 
-    - name: Verify cluster has more than 5 pods running.
+    - name: Verify cluster has more than 3 pods running.
       assert:
-        that: (pod_list.resources | count) > 5
+        that: (pod_list.resources | count) > 3
 
     - include_tasks: tasks/delete.yml
     - include_tasks: tasks/scale.yml


### PR DESCRIPTION
With minishift, there is just 3 pods running.