### PR TITLE
molecule: conditional statements should not include jinja2 templating

### DIFF
--- a/molecule/default/tasks/scale.yml
+++ b/molecule/default/tasks/scale.yml
@@ -64,7 +64,7 @@
         field_selectors:
           - status.phase=Running
       register: scale_down_deploy_pods
-      until: "{{ scale_down_deploy_pods.resources | length == 0 }}"
+      until: scale_down_deploy_pods.resources | length == 0
       retries: 6
       delay: 5
 
@@ -193,7 +193,7 @@
       register: scale_down_no_wait_pods
       retries: 6
       delay: 5
-      until: "{{ scale_down_no_wait_pods.resources | length == 1 }}"
+      until: scale_down_no_wait_pods.resources | length == 1
 
     - name: Ensure that scale down without wait worked
       assert:

--- a/molecule/default/tasks/waiter.yml
+++ b/molecule/default/tasks/waiter.yml
@@ -249,7 +249,7 @@
         field_selectors:
           - status.phase=Running
       register: updated_deploy_pods
-      until: "{{ updated_deploy_pods.resources[0].spec.containers[0].image.endswith(':2') }}"
+      until: updated_deploy_pods.resources[0].spec.containers[0].image.endswith(':2')
       retries: 6
       delay: 5
 


### PR DESCRIPTION
This address the following warning:
```
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: {{ scale_down_no_wait_pods.resources
| length == 1 }
```