### PR TITLE
Update to latest version of kind action so kind cluster setup succeeds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           path: ansible_collections/community/kubernetes
 
       - name: Set up KinD cluster
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
 
       - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v1
@@ -169,7 +169,7 @@ jobs:
           path: ansible_collections/community/kubernetes
 
       - name: Set up KinD cluster
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
 
       - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v1


### PR DESCRIPTION
Currently our CI is failing when it goes to create a Kind cluster. We should fix that by updating the GitHub Action we're using to set up the cluster.﻿
