### PR TITLE
k8s_info now outputs whether the api was found

### DIFF
--- a/molecule/default/tasks/info.yml
+++ b/molecule/default/tasks/info.yml
@@ -159,6 +159,29 @@
           - multi_pod_two_remove is successful
           - multi_pod_two_remove.changed
 
+    - name: "Look for existing API"
+      k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+      register: existing_api
+
+    - name: Check if we informed the user the api does exist
+      assert:
+        that:
+          - existing_api.api_found
+
+    - name: "Look for non-existent API"
+      k8s_info:
+        api_version: pleasedonotcreatethisresource.example.com/v7
+        kind: DoesNotExist
+      register: dne_api
+
+    - name: Check if we informed the user the api does not exist
+      assert:
+        that:
+          - not dne_api.resources
+          - not dne_api.api_found
+
   always:
     - name: Remove namespace
       k8s:

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -288,7 +288,7 @@ class K8sAnsibleMixin(object):
         resource = self.find_resource(kind, api_version)
         api_found = bool(resource)
         if not api_found:
-            return dict(resources=[], msg='Failed to resource with apiVersion "{0}" and kind "{1}"'.format(api_version, kind), api_found=False)
+            return dict(resources=[], msg='Failed to find API for resource with apiVersion "{0}" and kind "{1}"'.format(api_version, kind), api_found=False)
 
         if not label_selectors:
             label_selectors = []

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -290,7 +290,6 @@ class K8sAnsibleMixin(object):
         if not api_found:
             return dict(resources=[], msg='Failed to resource with apiVersion "{0}" and kind "{1}"'.format(api_version, kind), api_found=False)
 
-
         if not label_selectors:
             label_selectors = []
         if not field_selectors:

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -286,8 +286,10 @@ class K8sAnsibleMixin(object):
     def kubernetes_facts(self, kind, api_version, name=None, namespace=None, label_selectors=None, field_selectors=None,
                          wait=False, wait_sleep=5, wait_timeout=120, state='present', condition=None):
         resource = self.find_resource(kind, api_version)
-        if not resource:
-            return dict(resources=[])
+        api_found = bool(resource)
+        if not api_found:
+            return dict(resources=[], msg='Failed to resource with apiVersion "{0}" and kind "{1}"'.format(api_version, kind), api_found=False)
+
 
         if not label_selectors:
             label_selectors = []
@@ -315,14 +317,14 @@ class K8sAnsibleMixin(object):
                             self.fail(msg="Failed to gather information about %s(s) even"
                                           " after waiting for %s seconds" % (res.get('kind'), duration))
                         satisfied_by.append(res)
-                    return dict(resources=satisfied_by)
+                    return dict(resources=satisfied_by, api_found=True)
             result = result.to_dict()
         except (openshift.dynamic.exceptions.BadRequestError, openshift.dynamic.exceptions.NotFoundError):
-            return dict(resources=[])
+            return dict(resources=[], api_found=True)
 
         if 'items' in result:
-            return dict(resources=result['items'])
-        return dict(resources=[result])
+            return dict(resources=result['items'], api_found=True)
+        return dict(resources=[result], api_found=True)
 
     def remove_aliases(self):
         """

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -112,6 +112,11 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
+api_found:
+  description:
+  - Whether the specified api_version and kind were successfully mapped to an existing API on the targeted cluster.
+  returned: always
+  type: boolean
 resources:
   description:
   - The object(s) that exists

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -116,7 +116,7 @@ api_found:
   description:
   - Whether the specified api_version and kind were successfully mapped to an existing API on the targeted cluster.
   returned: always
-  type: boolean
+  type: bool
 resources:
   description:
   - The object(s) that exists


### PR DESCRIPTION
##### SUMMARY
Previously, an empty list of resources could mean two things:
1. There were no instances of resources matching the api_version and
   kind found in the cluster.
2. There was no API found that matched the provided api_version and
   kind.

This adds a new field to the k8s_info output, `api_found`, which is a
boolean that allows this ambiguity to be resolved by the user without
additional steps.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
