### PR TITLE
test: k8s's merge_type expect a list

### DIFF
--- a/molecule/default/tasks/crd.yml
+++ b/molecule/default/tasks/crd.yml
@@ -36,7 +36,8 @@
         - name: Recreate custom resource definition with merge_type
           k8s:
             definition: "{{ lookup('file', kubernetes_role_path + '/files/crd-resource.yml') }}"
-            merge_type: merge
+            merge_type:
+              - merge
             namespace: crd
           register: recreate_crd_with_merge
 


### PR DESCRIPTION
The `merge_type` parameter of `k8s` is a list, not a string.