### PR TITLE
The type of wait_condition.status is str

### DIFF
--- a/changelogs/fragments/310-wait_condition.status_is_a_str.yaml
+++ b/changelogs/fragments/310-wait_condition.status_is_a_str.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Adjust the documentation to clarify the fact ``wait_condition.status`` is a string.

--- a/plugins/doc_fragments/k8s_wait_options.py
+++ b/plugins/doc_fragments/k8s_wait_options.py
@@ -52,9 +52,9 @@ options:
         - The value of the status field in your desired condition.
         - For example, if a C(Deployment) is paused, the C(Progressing) C(type) will have the C(Unknown) status.
         choices:
-        - True
-        - False
-        - Unknown
+        - "True"
+        - "False"
+        - "Unknown"
         default: "True"
       reason:
         type: str

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -30,6 +30,8 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import dict_merge
+from ansible.module_utils.parsing.convert_bool import boolean
+
 
 K8S_IMP_ERR = None
 try:
@@ -181,7 +183,7 @@ WAIT_ARG_SPEC = dict(
         default=None,
         options=dict(
             type=dict(),
-            status=dict(default=True, choices=[True, False, "Unknown"]),
+            status=dict(type='str', default="True", choices=["True", "False", "Unknown"]),
             reason=dict()
         )
     )
@@ -438,7 +440,7 @@ class K8sAnsibleMixin(object):
                         return match.reason == condition['reason']
                 return False
             status = True if match.status == 'True' else False
-            if status == condition['status']:
+            if status == boolean(condition['status']):
                 if condition.get('reason'):
                     return match.reason == condition['reason']
                 return True


### PR DESCRIPTION
The `wait_condition.status` key is a string.

- Use actually string in the documentation
- Use core's `boolean()` method to convert the value internally to
  boolean