### PR TITLE
helm: add support for the K8S_ envvars

### DIFF
--- a/changelogs/fragments/319-helm-honors-HELM_-environment-variables.yaml
+++ b/changelogs/fragments/319-helm-honors-HELM_-environment-variables.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- The Helm modules (``helm``, ``helm_info``, ``helm_plugin``, ``helm_plugin_info``, ``helm_plugin_repository``) accept
+  the K8S environment variables like the other modules of the collections.

--- a/molecule/default/roles/helm/tasks/run_test.yml
+++ b/molecule/default/roles/helm/tasks/run_test.yml
@@ -12,6 +12,9 @@
 - name: "Install {{ helm_version }}"
   include_tasks: install.yml
 
+- name: "Ensure we honor the environment variables"
+  include_tasks: test_read_envvars.yml
+
 - name: tests_repository
   include_tasks: tests_repository.yml
 

--- a/molecule/default/roles/helm/tasks/test_read_envvars.yml
+++ b/molecule/default/roles/helm/tasks/test_read_envvars.yml
@@ -1,0 +1,10 @@
+- name: Pass a bogus server through the K8S_AUTH_HOST environment variable and ensure helm fails as expected
+  helm:
+    binary_path: "{{ helm_binary }}"
+    state: absent
+    name: does-not-exist
+    namespace: "{{ helm_namespace }}"
+  environment:
+    K8S_AUTH_HOST: somewhere
+  register: _helm_result
+  failed_when: '"http://somewhere/version" not in _helm_result.stderr'

--- a/plugins/doc_fragments/helm_common_options.py
+++ b/plugins/doc_fragments/helm_common_options.py
@@ -31,4 +31,29 @@ options:
       - If the value is not specified in the task, the value of environment variable C(K8S_AUTH_KUBECONFIG) will be used instead.
     type: path
     aliases: [ kubeconfig_path ]
+  host:
+    description:
+    - Provide a URL for accessing the API. Can also be specified via C(K8S_AUTH_HOST) environment variable.
+    type: str
+    version_added: "1.2.0"
+  api_key:
+    description:
+    - Token used to authenticate with the API. Can also be specified via C(K8S_AUTH_API_KEY) environment variable.
+    type: str
+    version_added: "1.2.0"
+  validate_certs:
+    description:
+    - Whether or not to verify the API server's SSL certificates. Can also be specified via C(K8S_AUTH_VERIFY_SSL)
+      environment variable.
+    type: bool
+    aliases: [ verify_ssl ]
+    default: True
+    version_added: "1.2.0"
+  ca_cert:
+    description:
+    - Path to a CA certificate used to authenticate with the API. The full certificate chain must be provided to
+      avoid certificate validation errors. Can also be specified via C(K8S_AUTH_SSL_CA_CERT) environment variable.
+    type: path
+    aliases: [ ssl_ca_cert ]
+    version_added: "1.2.0"
 '''

--- a/plugins/module_utils/helm.py
+++ b/plugins/module_utils/helm.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+from contextlib import contextmanager
+import os
+import tempfile
+import traceback
+
+from ansible.module_utils.basic import missing_required_lib
+
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    YAML_IMP_ERR = traceback.format_exc()
+    HAS_YAML = False
+
+
+@contextmanager
+def prepare_helm_environ_update(module):
+    environ_update = {}
+    file_to_cleam_up = None
+    kubeconfig_path = module.params.get('kubeconfig')
+    if module.params.get('kube_context') is not None:
+        environ_update["HELM_KUBECONTEXT"] = module.params.get('kube_context')
+    if module.params.get('release_namespace'):
+        environ_update["HELM_NAMESPACE"] = module.params.get('release_namespace')
+    if module.params.get("api_key"):
+        environ_update["HELM_KUBETOKEN"] = module.params["api_key"]
+    if module.params.get("host"):
+        environ_update["HELM_KUBEAPISERVER"] = module.params["host"]
+    if module.params.get("validate_certs") is False or module.params.get("ca_cert"):
+        kubeconfig_path = write_temp_kubeconfig(
+            module.params["host"],
+            validate_certs=module.params["validate_certs"],
+            ca_cert=module.params["ca_cert"])
+        file_to_cleam_up = kubeconfig_path
+    if kubeconfig_path is not None:
+        environ_update["KUBECONFIG"] = kubeconfig_path
+
+    try:
+        yield environ_update
+    finally:
+        if file_to_cleam_up:
+            os.remove(file_to_cleam_up)
+
+
+def run_helm(module, command, fails_on_error=True):
+    if not HAS_YAML:
+        module.fail_json(msg=missing_required_lib("PyYAML"), exception=YAML_IMP_ERR)
+
+    with prepare_helm_environ_update(module) as environ_update:
+        rc, out, err = module.run_command(command, environ_update=environ_update)
+    if fails_on_error and rc != 0:
+        module.fail_json(
+            msg="Failure when executing Helm command. Exited {0}.\nstdout: {1}\nstderr: {2}".format(rc, out, err),
+            stdout=out,
+            stderr=err,
+            command=command,
+        )
+    return rc, out, err
+
+
+def get_values(module, command, release_name):
+    """
+    Get Values from deployed release
+    """
+    if not HAS_YAML:
+        module.fail_json(msg=missing_required_lib("PyYAML"), exception=YAML_IMP_ERR)
+
+    get_command = command + " get values --output=yaml " + release_name
+
+    rc, out, err = run_helm(module, get_command)
+    # Helm 3 return "null" string when no values are set
+    if out.rstrip("\n") == "null":
+        return {}
+    return yaml.safe_load(out)
+
+
+def write_temp_kubeconfig(server, validate_certs=True, ca_cert=None):
+    # Workaround until https://github.com/helm/helm/pull/8622 is merged
+    content = {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "clusters": [
+            {
+                "cluster": {
+                    "server": server,
+                },
+                "name": "generated-cluster"
+            }
+        ],
+        "contexts": [
+            {
+                "context": {
+                    "cluster": "generated-cluster"
+                },
+                "name": "generated-context"
+            }
+        ],
+        "current-context": "generated-context"
+    }
+
+    if not validate_certs:
+        content["clusters"][0]["cluster"]["insecure-skip-tls-verify"] = True
+    if ca_cert:
+        content["clusters"][0]["cluster"]["certificate-authority"] = ca_cert
+
+    _fd, file_name = tempfile.mkstemp()
+    with os.fdopen(_fd, 'w') as fp:
+        yaml.dump(content, fp)
+    return file_name

--- a/plugins/modules/helm_info.py
+++ b/plugins/modules/helm_info.py
@@ -99,27 +99,7 @@ except ImportError:
     IMP_YAML = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
-
-module = None
-
-
-# Get Values from deployed release
-def get_values(command, release_name):
-    get_command = command + " get values --output=yaml " + release_name
-
-    rc, out, err = module.run_command(get_command)
-
-    if rc != 0:
-        module.fail_json(
-            msg="Failure when executing Helm command. Exited {0}.\nstdout: {1}\nstderr: {2}".format(rc, out, err),
-            command=get_command
-        )
-
-    # Helm 3 return "null" string when no values are set
-    if out.rstrip("\n") == "null":
-        return {}
-    else:
-        return yaml.safe_load(out)
+from ansible_collections.community.kubernetes.plugins.module_utils.helm import run_helm, get_values
 
 
 # Get Release from all deployed releases
@@ -132,10 +112,10 @@ def get_release(state, release_name):
 
 
 # Get Release state from deployed release
-def get_release_status(command, release_name):
+def get_release_status(module, command, release_name):
     list_command = command + " list --output=yaml --filter " + release_name
 
-    rc, out, err = module.run_command(list_command)
+    rc, out, err = run_helm(module, list_command)
 
     if rc != 0:
         module.fail_json(
@@ -148,7 +128,7 @@ def get_release_status(command, release_name):
     if release is None:  # not install
         return None
 
-    release['values'] = get_values(command, release_name)
+    release['values'] = get_values(module, command, release_name)
 
     return release
 
@@ -165,7 +145,19 @@ def main():
             # Helm options
             context=dict(type='str', aliases=['kube_context'], fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
             kubeconfig=dict(type='path', aliases=['kubeconfig_path'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
+
+            # Generic auth key
+            host=dict(type='str', fallback=(env_fallback, ['K8S_AUTH_HOST'])),
+            ca_cert=dict(type='path', aliases=['ssl_ca_cert'], fallback=(env_fallback, ['K8S_AUTH_SSL_CA_CERT'])),
+            validate_certs=dict(type='bool', default=True, aliases=['verify_ssl'], fallback=(env_fallback, ['K8S_AUTH_VERIFY_SSL'])),
+            api_key=dict(type='str', no_log=True, fallback=(env_fallback, ['K8S_AUTH_API_KEY']))
         ),
+        mutually_exclusive=[
+            ("context", "ca_cert"),
+            ("context", "validate_certs"),
+            ("kubeconfig", "ca_cert"),
+            ("kubeconfig", "validate_certs")
+        ],
         supports_check_mode=True,
     )
 
@@ -174,26 +166,13 @@ def main():
 
     bin_path = module.params.get('binary_path')
     release_name = module.params.get('release_name')
-    release_namespace = module.params.get('release_namespace')
-
-    # Helm options
-    kube_context = module.params.get('context')
-    kubeconfig_path = module.params.get('kubeconfig')
 
     if bin_path is not None:
         helm_cmd_common = bin_path
     else:
         helm_cmd_common = module.get_bin_path('helm', required=True)
 
-    if kube_context is not None:
-        helm_cmd_common += " --kube-context " + kube_context
-
-    if kubeconfig_path is not None:
-        helm_cmd_common += " --kubeconfig " + kubeconfig_path
-
-    helm_cmd_common += " --namespace=" + release_namespace
-
-    release_status = get_release_status(helm_cmd_common, release_name)
+    release_status = get_release_status(module, helm_cmd_common, release_name)
 
     if release_status is not None:
         module.exit_json(changed=False, status=release_status)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+kubernetes-validate

--- a/tests/unit/module_utils/test_helm.py
+++ b/tests/unit/module_utils/test_helm.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import os.path
+
+import yaml
+
+
+from ansible_collections.community.kubernetes.plugins.module_utils.helm import (
+    run_helm,
+    write_temp_kubeconfig,
+)
+
+
+class MockedModule:
+    def __init__(self):
+
+        self.params = {
+            "api_key": None,
+            "ca_cert": None,
+            "host": None,
+            "kube_context": None,
+            "kubeconfig": None,
+            "release_namespace": None,
+            "validate_certs": None,
+        }
+
+        self.r = {}
+
+    def run_command(self, command, environ_update=None):
+        self.r = {"command": command, "environ_update": environ_update}
+        return 0, "", ""
+
+
+def test_write_temp_kubeconfig_server_only():
+    file_name = write_temp_kubeconfig("ff")
+    try:
+        with open(file_name, "r") as fd:
+            content = yaml.load(fd)
+    finally:
+        os.remove(file_name)
+
+    assert content == {
+        "apiVersion": "v1",
+        "clusters": [{"cluster": {"server": "ff"}, "name": "generated-cluster"}],
+        "contexts": [
+            {"context": {"cluster": "generated-cluster"}, "name": "generated-context"}
+        ],
+        "current-context": "generated-context",
+        "kind": "Config",
+    }
+
+
+def test_write_temp_kubeconfig_server_inscure_certs():
+    file_name = write_temp_kubeconfig("ff", False, "my-certificate")
+    try:
+        with open(file_name, "r") as fd:
+            content = yaml.load(fd)
+    finally:
+        os.remove(file_name)
+
+    assert content["clusters"][0]["cluster"]["insecure-skip-tls-verify"] is True
+    assert (
+        content["clusters"][0]["cluster"]["certificate-authority"] == "my-certificate"
+    )
+
+
+def test_run_helm_naked():
+    module = MockedModule()
+    run_helm(module, "helm foo")
+
+    assert module.r["command"] == "helm foo"
+    assert module.r["environ_update"] == {}
+
+
+def test_run_helm_with_params():
+    module = MockedModule()
+    module.params = {
+        "api_key": "my-api-key",
+        "ca_cert": "my-ca-cert",
+        "host": "some-host",
+        "kube_context": "my-context",
+        "release_namespace": "a-release-namespace",
+        "validate_certs": False,
+    }
+
+    run_helm(module, "helm foo")
+
+    assert module.r["command"] == "helm foo"
+    assert module.r["environ_update"]["HELM_KUBEAPISERVER"] == "some-host"
+    assert module.r["environ_update"]["HELM_KUBECONTEXT"] == "my-context"
+    assert module.r["environ_update"]["HELM_KUBETOKEN"] == "my-api-key"
+    assert module.r["environ_update"]["HELM_NAMESPACE"] == "a-release-namespace"
+    assert module.r["environ_update"]["KUBECONFIG"]
+    assert not os.path.exists(module.r["environ_update"]["KUBECONFIG"])

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+PyYAML


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.kubernetes/pull/324

Add support for:

- K8S_AUTH_HOST
- K8S_AUTH_API_KEY
- K8S_AUTH_VERIFY_SSL
- K8S_AUTH_SSL_CA_CERT

This commit also refactor the way we pass K8S related configuration to `helm`:

All the calls are now done in a new module_utils module (`helm.py`).
The handling of the `kube_*` variables has also been moved in this new
module.

We need https://github.com/helm/helm/pull/8622 to be able to ignore the
certificate validation. As a workaround, the generate a temporary
kubeconfig configuration file.

Closes: #279