### PR TITLE
helm and helm_info: adjust the name of two parameters

### DIFF
--- a/changelogs/fragments/324-adjust-helm-and-helm_info-parameters-names.yaml
+++ b/changelogs/fragments/324-adjust-helm-and-helm_info-parameters-names.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- Adjust the name of parameters of ``helm`` and ``helm_info`` to match the documentation. No playbook change required.

--- a/plugins/modules/helm.py
+++ b/plugins/modules/helm.py
@@ -432,8 +432,8 @@ def main():
             # Helm options
             disable_hook=dict(type='bool', default=False),
             force=dict(type='bool', default=False),
-            kube_context=dict(type='str', aliases=['context'], fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
-            kubeconfig_path=dict(type='path', aliases=['kubeconfig'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
+            context=dict(type='str', aliases=['kube_context'], fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
+            kubeconfig=dict(type='path', aliases=['kubeconfig_path'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
             purge=dict(type='bool', default=True),
             wait=dict(type='bool', default=False),
             wait_timeout=dict(type='str'),
@@ -467,8 +467,8 @@ def main():
     # Helm options
     disable_hook = module.params.get('disable_hook')
     force = module.params.get('force')
-    kube_context = module.params.get('kube_context')
-    kubeconfig_path = module.params.get('kubeconfig_path')
+    kube_context = module.params.get('context')
+    kubeconfig_path = module.params.get('kubeconfig')
     purge = module.params.get('purge')
     wait = module.params.get('wait')
     wait_timeout = module.params.get('wait_timeout')

--- a/plugins/modules/helm_info.py
+++ b/plugins/modules/helm_info.py
@@ -163,8 +163,8 @@ def main():
             release_namespace=dict(type='str', required=True, aliases=['namespace']),
 
             # Helm options
-            kube_context=dict(type='str', aliases=['context'], fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
-            kubeconfig_path=dict(type='path', aliases=['kubeconfig'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
+            context=dict(type='str', aliases=['kube_context'], fallback=(env_fallback, ['K8S_AUTH_CONTEXT'])),
+            kubeconfig=dict(type='path', aliases=['kubeconfig_path'], fallback=(env_fallback, ['K8S_AUTH_KUBECONFIG'])),
         ),
         supports_check_mode=True,
     )
@@ -177,8 +177,8 @@ def main():
     release_namespace = module.params.get('release_namespace')
 
     # Helm options
-    kube_context = module.params.get('kube_context')
-    kubeconfig_path = module.params.get('kubeconfig_path')
+    kube_context = module.params.get('context')
+    kubeconfig_path = module.params.get('kubeconfig')
 
     if bin_path is not None:
         helm_cmd_common = bin_path

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,5 +1,3 @@
-plugins/modules/helm.py validate-modules:parameter-type-not-in-doc
-plugins/modules/helm_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s.py validate-modules:return-syntax-error
 plugins/modules/k8s_scale.py validate-modules:parameter-type-not-in-doc

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,5 +1,3 @@
-plugins/modules/helm.py validate-modules:parameter-type-not-in-doc
-plugins/modules/helm_info.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s_scale.py validate-modules:parameter-type-not-in-doc
 plugins/modules/k8s_service.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
According to the documentation fragment and the other modules:
- the `kube_context` option should be named `context`
- the `kubeconfig_path` option should be named `kubeconfig`.