### PR TITLE
add 3 doc-default-does-not-match-spec errors

### DIFF
--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -87,6 +87,7 @@ options:
       will only work if the same object is passed with state=absent (alternatively, just use state=absent with the name including
       the generated hash and append_hash=no)
     - Requires openshift >= 0.7.2
+    default: False
     type: bool
   apply:
     description:
@@ -95,6 +96,7 @@ options:
     - C(apply) works better with Services than 'force=yes'
     - Requires openshift >= 0.9.2
     - mutually exclusive with C(merge_type)
+    default: False
     type: bool
   template:
     description:

--- a/plugins/modules/k8s_service.py
+++ b/plugins/modules/k8s_service.py
@@ -81,6 +81,7 @@ options:
       ignoring properties that are automatically generated
     - C(apply) works better with Services than 'force=yes'
     - mutually exclusive with C(merge_type)
+    default: False
     type: bool
 
 requirements:


### PR DESCRIPTION
Address the following error with the test-suite:

- plugins/modules/k8s.py:0:0: doc-default-does-not-match-spec: Argument 'append_hash' in argument_spec defines default as (False) but documentation defines default as (None)
- plugins/modules/k8s.py:0:0: doc-default-does-not-match-spec: Argument 'apply' in argument_spec defines default as (False) but documentation defines default as (None)
- plugins/modules/k8s_service.py:0:0: doc-default-does-not-match-spec: Argument 'apply' in argument_spec defines default as (False) but documentation defines default as (None)