### PR TITLE
Honor wait_timeout in k8s_info for missing resource

### DIFF
--- a/changelogs/fragments/360-k8s_info-wait-timeout.yaml
+++ b/changelogs/fragments/360-k8s_info-wait-timeout.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - respect the ``wait_timeout`` parameter in the ``k8s`` and ``k8s_info`` modules when a resource does not exist (https://github.com/ansible-collections/community.kubernetes/issues/344).

--- a/molecule/default/tasks/info.yml
+++ b/molecule/default/tasks/info.yml
@@ -182,6 +182,24 @@
           - not dne_api.resources
           - not dne_api.api_found
 
+    - name: Start timer
+      set_fact:
+        start: "{{ lookup('pipe', 'date +%s') }}"
+
+    - name: Wait for non-existent pod to be created
+      k8s_info:
+        kind: Pod
+        name: does-not-exist
+        namespace: "{{ wait_namespace }}"
+        wait: yes
+        wait_timeout: 45
+      register: result
+
+    - name: Check that module waited
+      assert:
+        that:
+          - "{{ lookup('pipe', 'date +%s') }} - {{ start }} > 30"
+
   always:
     - name: Remove namespace
       k8s:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The wait logic in the k8s_info module immediately returns when no
resources are found, regardless whether a wait_timeout has been
specified. This expands the logic to wait when a name has been provided.
The case this is specifically meant to address is when querying for a
resource that is indirectly created by another resource, for example, a
pod created by a deployment or an operator.

The existing logic in every other case should remain as it was before.
This means if a query might return more than one resource--all pods with
some label, for example--the module will return immediately if no pods
are found, even if a wait_timeout has been provided.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Closes #344 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s_info, k8s

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
