### PR TITLE
Update minimum version of Ansible required

### DIFF
--- a/changelogs/fragments/314_version.yml
+++ b/changelogs/fragments/314_version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- runtime.yml - update minimum Ansible version required for Kubernetes collection (https://github.com/ansible-collections/community.kubernetes/issues/314).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.9'
+requires_ansible: '>=2.9.17'
 
 action_groups:
   helm:


### PR DESCRIPTION
##### SUMMARY

https://github.com/ansible-collections/community.kubernetes/pull/276
is backported to 2.9.17
Any Ansible version lesser than this will not work due to
Kubernetes-python compatibility issues.

Fixes: #314
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/314_version.yml
meta/runtime.yml
