### PR TITLE
pylint: ignores some py3 specific tests

### DIFF
--- a/plugins/action/k8s_info.py
+++ b/plugins/action/k8s_info.py
@@ -3,6 +3,9 @@
 # Copyright (c) 2020, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+# pylint: disable=raise-missing-from
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -109,7 +112,7 @@ class ActionModule(ActionBase):
         # Option `lstrip_blocks' was added in Jinja2 version 2.7.
         if lstrip_blocks:
             try:
-                import jinja2.defaults
+                import jinja2.defaults  # pylint: disable=import-outside-toplevel
             except ImportError:
                 raise AnsibleError('Unable to import Jinja2 defaults for determining Jinja2 features.')
 

--- a/plugins/connection/kubectl.py
+++ b/plugins/connection/kubectl.py
@@ -17,6 +17,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=super-with-arguments
+# pylint: disable=raise-missing-from
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/filter/k8s.py
+++ b/plugins/filter/k8s.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=raise-missing-from
+
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/plugins/inventory/k8s.py
+++ b/plugins/inventory/k8s.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2018 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=raise-missing-from
+# pylint: disable=super-with-arguments
+
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/inventory/openshift.py
+++ b/plugins/inventory/openshift.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2018 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+# pylint: disable=raise-missing-from
+
+
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type

--- a/plugins/module_utils/raw.py
+++ b/plugins/module_utils/raw.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/plugins/module_utils/scale.py
+++ b/plugins/module_utils/scale.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -4,6 +4,9 @@
 # (c) 2018, Chris Houseknecht <@chouseknecht>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/plugins/modules/k8s_cluster_info.py
+++ b/plugins/modules/k8s_cluster_info.py
@@ -3,6 +3,9 @@
 # Copyright (c) 2020, Abhijeet Kasurde
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/plugins/modules/k8s_exec.py
+++ b/plugins/modules/k8s_exec.py
@@ -4,6 +4,9 @@
 # Copyright (c) 2020, Red Hat
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/plugins/modules/k8s_info.py
+++ b/plugins/modules/k8s_info.py
@@ -4,6 +4,9 @@
 # (c) 2018, Will Thames <@willthames>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/plugins/modules/k8s_log.py
+++ b/plugins/modules/k8s_log.py
@@ -4,6 +4,9 @@
 # (c) 2019, Fabian von Feilitzsch <@fabianvf>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/plugins/modules/k8s_rollback.py
+++ b/plugins/modules/k8s_rollback.py
@@ -4,6 +4,9 @@
 # Copyright: (c) 2020, Julien Huon <@julienhuon> Institut National de l'Audiovisuel
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/plugins/modules/k8s_service.py
+++ b/plugins/modules/k8s_service.py
@@ -4,6 +4,9 @@
 # Copyright (c) 2018, KubeVirt Team <@kubevirt>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# pylint: disable=super-with-arguments
+
+
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -5,3 +5,17 @@ molecule/default/roles/helm/files/appversionless-chart-v2/templates/configmap.ya
 molecule/default/roles/helm/files/appversionless-chart/templates/configmap.yaml yamllint!skip
 molecule/default/roles/helm/files/test-chart-v2/templates/configmap.yaml yamllint!skip
 molecule/default/roles/helm/files/test-chart/templates/configmap.yaml yamllint!skip
+plugins/action/k8s_info.py pylint:bad-option-value
+plugins/connection/kubectl.py pylint:bad-option-value
+plugins/filter/k8s.py pylint:bad-option-value
+plugins/inventory/k8s.py pylint:bad-option-value
+plugins/inventory/openshift.py pylint:bad-option-value
+plugins/module_utils/raw.py pylint:bad-option-value
+plugins/module_utils/scale.py pylint:bad-option-value
+plugins/modules/k8s.py pylint:bad-option-value
+plugins/modules/k8s_cluster_info.py pylint:bad-option-value
+plugins/modules/k8s_exec.py pylint:bad-option-value
+plugins/modules/k8s_info.py pylint:bad-option-value
+plugins/modules/k8s_log.py pylint:bad-option-value
+plugins/modules/k8s_rollback.py pylint:bad-option-value
+plugins/modules/k8s_service.py pylint:bad-option-value


### PR DESCRIPTION
- `super-with-arguments`
- `raise-missing-from`

Also ignore an `import-outside-toplevel` error. Finally, we ignore `base-option-value` with Ansible 2.9. The `pylint` version is too old.