### PR TITLE
Adds a wait example to k8s.py

### DIFF
--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -221,6 +221,23 @@ EXAMPLES = r'''
   community.kubernetes.k8s:
     state: present
     src: ~/metrics-server.yaml
+
+# Wait for a Deployment to pause before continuing
+- name: Pause a Deployment.
+  k8s:
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: example
+        namespace: testing
+      spec:
+        paused: True
+    wait: yes
+    wait_condition:
+      type: Progressing
+      status: Unknown
+      reason: DeploymentPaused
 '''
 
 RETURN = r'''

--- a/plugins/modules/k8s.py
+++ b/plugins/modules/k8s.py
@@ -224,7 +224,7 @@ EXAMPLES = r'''
 
 # Wait for a Deployment to pause before continuing
 - name: Pause a Deployment.
-  k8s:
+  community.kubernetes.k8s:
     definition:
       apiVersion: apps/v1
       kind: Deployment


### PR DESCRIPTION
##### SUMMARY

The k8s module didn't have an example using its wait capabilities. This fixes that by lifting an example from the blog post that introduced the feature.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

k8s.py

