### PR TITLE
Fix helm ignoring given context

### DIFF
--- a/changelogs/fragments/387-fix-helm-ignoring-context.yaml
+++ b/changelogs/fragments/387-fix-helm-ignoring-context.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - helm - fix helm ignoring the kubeconfig context when passed through the ``context`` param or the ``K8S_AUTH_CONTEXT`` environment variable (https://github.com/ansible-collections/community.kubernetes/issues/385).

--- a/molecule/default/roles/helm/tasks/tests_chart.yml
+++ b/molecule/default/roles/helm/tasks/tests_chart.yml
@@ -348,6 +348,24 @@
         that:
           result.stat.exists
 
+    - name: Release using non-existent context
+      helm:
+        binary_path: "{{ helm_binary }}"
+        name: test
+        chart_ref: "{{ chart_source }}"
+        chart_version: "{{ chart_source_version | default(omit) }}"
+        namespace: "{{ helm_namespace }}"
+        create_namespace: true
+        context: does-not-exist
+      ignore_errors: yes
+      register: result
+
+    - name: Assert that release fails with non-existent context
+      assert:
+        that:
+          - result is failed
+          - "'context \"does-not-exist\" does not exist' in result.stderr"
+
   always:
     - name: Clean up temp dir
       file:

--- a/plugins/module_utils/helm.py
+++ b/plugins/module_utils/helm.py
@@ -28,8 +28,8 @@ def prepare_helm_environ_update(module):
     environ_update = {}
     file_to_cleam_up = None
     kubeconfig_path = module.params.get('kubeconfig')
-    if module.params.get('kube_context') is not None:
-        environ_update["HELM_KUBECONTEXT"] = module.params.get('kube_context')
+    if module.params.get('context') is not None:
+        environ_update["HELM_KUBECONTEXT"] = module.params.get('context')
     if module.params.get('release_namespace'):
         environ_update["HELM_NAMESPACE"] = module.params.get('release_namespace')
     if module.params.get("api_key"):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The helm module supports specifying a kubeconfig context in three
different ways, but was only using it if passed through the kube_context
parameter. This fixes it to support all three ways.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #385 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
helm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
