### PR TITLE
[bp/1.2] Restrict molecule version to <3.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,10 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
+      # The 3.3.0 release of molecule introduced a breaking change. See
+      # https://github.com/ansible-community/molecule/issues/3083
       - name: Install molecule and openshift dependencies
-        run: pip install ansible molecule yamllint openshift flake8
+        run: pip install ansible "molecule<3.3.0" yamllint openshift flake8
 
       # The latest release doesn't work with Molecule currently.
       # See: https://github.com/ansible-community/molecule/issues/2757
@@ -177,7 +179,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
 
       - name: Install molecule and openshift dependencies
-        run: pip install "ansible>=2.9.0,<2.10.0" molecule yamllint openshift flake8
+        run: pip install "ansible>=2.9.0,<2.10.0" "molecule<3.3.0" yamllint openshift flake8
 
       - name: Create default collection path symlink
         run: |

--- a/changelogs/fragments/403-pin-molecule.yaml
+++ b/changelogs/fragments/403-pin-molecule.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pin molecule version to <3.3.0 to fix breaking changes (https://github.com/ansible-collections/community.kubernetes/pull/403).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backporting #396.

The 3.3.0 version of molecule broke the test suite. Restricting the
version until we can either fix upstream or decide on the best
workaround.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
N/A
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
